### PR TITLE
Add support for A2A get passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -286,3 +286,6 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+
+# vi swap files
+.*.swp

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,36 @@
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+print_usage()
+{
+    cat <<EOF
+USAGE: run.sh [-v volume] [-h] [-c command]
+
+  -h  Show help and exit
+  -v  Directory from host to mount into container at /volume
+      This is useful for mounting a directory with certificates and private keys
+  -c  Alternate command to run in the container (often -c bash to get a prompt)
+      Always specify the -c option last
+
+EOF
+    exit 0
+}
+
+while getopts ":v:h" opt; do
+    case $opt in
+    v)
+        Volume=$OPTARG
+        shift; shift;
+        ;;
+    h)
+        print_usage
+        ;;
+    ?)
+        break
+        ;;
+    esac
+done
+
 if test -t 1; then
     YELLOW='\033[1;33m'
     NC='\033[0m'
@@ -16,7 +46,11 @@ if [ ! -z "$(which docker)" ]; then
             "You can specify an alternate startup command using arguments to this script.\n" \
             "The default entrypoint is bash, so use the -c argument.\n" \
             "  e.g. run.sh -c /bin/bash${NC}"
-    docker run -it safeguard-bash "$@"
+    if [ -z "$Volume" ]; then
+        docker run -it safeguard-bash "$@"
+    else
+        docker run -v "$Volume:/volume" -it safeguard-bash "$@"
+    fi
 else
     >&2 echo "You must install docker to use this script"
 fi

--- a/src/connect-safeguard.sh
+++ b/src/connect-safeguard.sh
@@ -16,7 +16,7 @@ USAGE: connect-safeguard.sh [-h]
   -u  Safeguard user to use
   -c  File containing client certificate
   -k  File containing client private key
-  -p  Read Safeguard password from stdin
+  -p  Read Safeguard or certificate password from stdin
   -X  Do NOT generate login file for use in other scripts
 
 The invoke-safeguard-method.sh and listen-for-safeguard-events.sh scripts will attempt
@@ -47,7 +47,7 @@ LoginFile="$HOME/.safeguard_login"
 require_args()
 {
     if [ -z "$Appliance" ]; then
-        read -p "Appliance network address: " Appliance
+        read -p "Appliance Network Address: " Appliance
     fi
 }
 

--- a/src/connect-safeguard.sh
+++ b/src/connect-safeguard.sh
@@ -111,10 +111,10 @@ get_rsts_token()
 EOF
         )
         if [ -z "$StsResponse" ]; then
-             # There is a bug in some Debian-based platforms with curl linked to GnuTLS where it doesn't properly
-             # ignore certificate errors when using client certificate authentication. This works around that
-             # problem by calling OpenSSL directly and manually formulating an HTTP request.
-             StsResponse=$(cat <<EOF | openssl s_client -connect $Appliance:443 -quiet -crlf -key $PKey -cert $Cert -pass pass:$Pass 2>&1
+            # There is a bug in some Debian-based platforms with curl linked to GnuTLS where it doesn't properly
+            # ignore certificate errors when using client certificate authentication. This works around that
+            # problem by calling OpenSSL directly and manually formulating an HTTP request.
+            StsResponse=$(cat <<EOF | openssl s_client -connect $Appliance:443 -quiet -crlf -key $PKey -cert $Cert -pass pass:$Pass 2>&1
 POST /RSTS/oauth2/token HTTP/1.1
 Host: $Appliance
 User-Agent: curl/7.47.0
@@ -125,7 +125,7 @@ Content-Length: 84
 
 {"grant_type":"client_credentials","scope":"rsts:sts:primaryproviderid:certificate"}
 EOF
-          )
+            )
         fi
         if [ $? -ne 0 ]; then
             >&2 echo "Failed to get access token from appliance token service"

--- a/src/connect-safeguard.sh
+++ b/src/connect-safeguard.sh
@@ -102,8 +102,11 @@ require_auth_args()
 get_rsts_token()
 {
     if [ "$Provider" = "certificate" ]; then
-        StsResponse=$(curl -s -k --key $PKey --cert $Cert --pass $Pass -X POST -H 'Accept: application/json' \
-                          -H 'Content-type: application/json' -d @- "https://$Appliance/RSTS/oauth2/token" <<EOF
+        if [ $(curl --version | grep "libcurl" | sed -e 's,curl [0-9]*\.\([0-9]*\).* (.*,\1,') -ge 33 ]; then
+            http11flag='--http1.1'
+        fi
+        StsResponse=$(curl -s -k --key $PKey --cert $Cert --pass $Pass $http11flag -X POST -H 'Accept: application/json' \
+                           -H 'Content-type: application/json' -d @- "https://$Appliance/RSTS/oauth2/token" <<EOF
 {
     "grant_type": "client_credentials",
     "scope": "$Scope"
@@ -265,7 +268,6 @@ EOF
         cat <<EOF >> $LoginFile
 Cert=$Cert
 PKey=$PKey
-Pass=$Pass
 EOF
     fi
     umask $OldUmask

--- a/src/connect-safeguard.sh
+++ b/src/connect-safeguard.sh
@@ -114,17 +114,16 @@ EOF
              # There is a bug in some Debian-based platforms with curl linked to GnuTLS where it doesn't properly
              # ignore certificate errors when using client certificate authentication. This works around that
              # problem by calling OpenSSL directly and manually formulating an HTTP request.
-             StsResponse=$(cat <<EOF | openssl s_client -connect $Appliance:443 -ign_eof -key $PKey -cert $Cert -pass pass:$Pass 2>&1
+             StsResponse=$(cat <<EOF | openssl s_client -connect $Appliance:443 -quiet -crlf -key $PKey -cert $Cert -pass pass:$Pass 2>&1
 POST /RSTS/oauth2/token HTTP/1.1
 Host: $Appliance
 User-Agent: curl/7.47.0
 Accept: application/json
+Connection: close
 Content-type: application/json
 Content-Length: 84
 
 {"grant_type":"client_credentials","scope":"rsts:sts:primaryproviderid:certificate"}
-
-Q
 EOF
           )
         fi

--- a/src/connect-safeguard.sh
+++ b/src/connect-safeguard.sh
@@ -149,12 +149,11 @@ EOF
             exit 1
         fi
     fi
-    TokenLine=$(echo $StsResponse | grep -Po '"access_token":.*?[^\\]",')
-    if [ $? -ne 0 ]; then
+    StsAccessToken=$(echo $StsResponse | sed -n 's/.*"access_token":"\([-0-9A-Za-z_\.]*\)",.*/\1/p')
+    if [ -z "$StsAccessToken" ]; then
         >&2 echo -e "Failed to get access token from appliance\n$StsResponse"
         exit 1
     fi
-    StsAccessToken=$(echo $TokenLine | sed -e 's/^.*:.*"\(.*\)",/\1/')
 }
 
 get_safeguard_token()
@@ -171,18 +170,17 @@ EOF
             >&2 echo -e "Failed to get login response from appliance:\n$LoginResponse"
             exit 1
         fi
-        Status=$(echo $LoginResponse | grep -Po '"Status":.*?[^\\]",')
-        if [ $? -ne 0 ]; then
+        Status=$(echo $LoginResponse | sed -n 's/.*"Status":"\([A-Za-z]*\)",.*/\1/p')
+        if [ -z "$Status" ]; then
             >&2 echo -e "Failed to get status from login response:\n$LoginResponse"
             exit 1
         fi
         if [[ $Status =~ .*Success* ]]; then
-            TokenLine=$(echo $LoginResponse | grep -Po '"UserToken":.*?[^\\]",')
-            if [ $? -ne 0 ]; then
+            AccessToken=$(echo $LoginResponse | sed -n 's/.*"UserToken":"\([-0-9A-Za-z_\.]*\)",.*/\1/p')
+            if [ -z "$AccessToken" ]; then
                 >&2 echo -e "Failed to get user token from appliance:\n$LoginResponse"
                 exit 1
             fi
-            AccessToken=$(echo $TokenLine | sed -e 's/^.*:.*"\(.*\)",/\1/')
         elif [[ $Status =~ .*Unauthorized* ]]; then
             >&2 echo -e "Failure result from login response:\n$LoginResponse"
             exit 1

--- a/src/disconnect-safeguard.sh
+++ b/src/disconnect-safeguard.sh
@@ -39,7 +39,6 @@ if [[ -r "$LoginFile" && -f "$LoginFile" ]]; then
     if [ "$Provider" = "certificate" ]; then
         Cert=$(read_from_login_file Cert)
         PKey=$(read_from_login_file PKey)
-        Pass=$(read_from_login_file Pass)
     fi
 else
     >&2 echo "A login file was not found or is not readable!"
@@ -51,11 +50,6 @@ rm -f $LoginFile
 
 >&2 echo "Calling logout service on appliance."
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-if [ "$Provider" = "certificate" ]; then
-    curl -s -S -k -H 'Accept: application/json' -H "Authorization: Bearer $AccessToken" \
-        --key $PKey --cert $Cert --pass $Pass "https://$Appliance/service/core/v$Version/Token/Logout" -d ""
-else
-    curl -s -S -k -H 'Accept: application/json' -H "Authorization: Bearer $AccessToken" \
-        "https://$Appliance/service/core/v$Version/Token/Logout" -d ""
-fi
+curl -s -S -k -H 'Accept: application/json' -H "Authorization: Bearer $AccessToken" \
+     "https://$Appliance/service/core/v$Version/Token/Logout" -d ""
 

--- a/src/get-a2a-password.sh
+++ b/src/get-a2a-password.sh
@@ -81,4 +81,19 @@ done
 
 require_args
 
-invoke_a2a_method "$Appliance" "$Cert" "$PKey" "$Pass" "$ApiKey" GET "Credentials?type=Password" $Version "$Body"
+
+
+ATTRFILTER='cat'
+ERRORFILTER='cat'
+if [ ! -z "$(which jq)" ]; then
+    ERRORFILTER='jq .'
+    ATTRFILTER='jq .'
+fi
+
+Result=$(invoke_a2a_method "$Appliance" "$Cert" "$PKey" "$Pass" "$ApiKey" GET "Credentials?type=Password" $Version "$Body")
+Error=$(echo $Result | jq .Code 2> /dev/null)
+if [ "$Error" = "null" ]; then
+    echo $Result | $ATTRFILTER
+else
+    echo $Result | $ERRORFILTER
+fi

--- a/src/get-a2a-password.sh
+++ b/src/get-a2a-password.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+print_usage()
+{
+    cat <<EOF
+USAGE: get-a2a-password.sh [-h]
+       get-a2a-password.sh [-a appliance] [-v version] [-c file] [-k file] [-A apikey] [-p]
+
+  -h  Show help and exit
+  -a  Network address of the appliance
+  -v  Web API Version: 2 is default
+  -c  File containing client certificate
+  -k  File containing client private key
+  -A  A2A API token identifying the account
+  -p  Read certificate password from stdin
+
+Retrieve a password using the Safeguard A2A service.
+
+EOF
+    exit 0
+}
+
+ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+
+Appliance=
+Version=2
+Cert=
+PKey=
+ApiKey=
+PassStdin=
+Pass=
+
+. "$ScriptDir/utils/a2a.sh"
+
+require_args()
+{
+    if [ -z "$Appliance" ]; then
+        read -p "Appliance Network Address: " Appliance
+    fi
+    if [ -z "$Cert" ]; then
+        read -p "Client Certificate File: " Cert
+    fi
+    if [ -z "$PKey" ]; then
+        read -p "Client Private Key File: " PKey
+    fi
+    if [ -z "$Pass" ]; then
+        read -s -p "Private Key Password: " Pass
+        >&2 echo
+    fi
+    if [ -z "$ApiKey" ]; then
+        read -p "A2A API Key: " ApiKey
+    fi
+}
+
+while getopts ":a:v:c:k:A:ph" opt; do
+    case $opt in
+    a)
+        Appliance=$OPTARG
+        ;;
+    v)
+        Version=$OPTARG
+        ;;
+    c)
+        Cert=$OPTARG
+        ;;
+    k)
+        PKey=$OPTARG
+        ;;
+    p)
+        PassStdin="-p"
+        ;;
+    A)
+        ApiKey=$OPTARG
+        ;;
+    h)
+        print_usage
+        ;;
+    esac
+done
+
+require_args
+
+invoke_a2a_method "$Appliance" "$Cert" "$PKey" "$Pass" "$ApiKey" GET "Credentials?type=Password" $Version "$Body"

--- a/src/utils/a2a.sh
+++ b/src/utils/a2a.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# This is a script to support calling the a2a service across multiple scripts.
+# It shouldn't be called directly.
+
+invoke_a2a_method()
+{
+    local appliance=$1 ; shift 
+    local certfile=$1 ; shift 
+    local pkeyfile=$1 ; shift 
+    local pass=$1 ; shift 
+    local apikey=$1 ; shift 
+    local method=$1 ; shift 
+    method=$(echo "$method" | tr '[:lower:]' '[:upper:]')
+    local relurl=$1 ; shift 
+    local version=$1 ; shift 
+    local body=$1 ; shift 
+
+    if [ -z "$body" ]; then
+        local response=$(curl -s -k --key $pkeyfile --cert $certfile --pass $pass -X $method -H 'Accept: application/json' \
+                              -H "Authorization: A2A $apikey" "https://$appliance/service/a2a/v$version/$relurl"
+        )
+        if [ -z "$reponse" ]; then
+            # There is a bug in some Debian-based platforms with curl linked to GnuTLS where it doesn't properly
+            # ignore certificate errors when using client certificate authentication. This works around that
+            # problem by calling OpenSSL directly and manually formulating an HTTP request.
+            response=$(cat <<EOF | openssl s_client -connect $appliance:443 -ign_eof -key $pkeyfile -cert $certfile -pass pass:$pass 2>&1
+$method /service/a2a/v$version/$relurl HTTP/1.1
+Host: $appliance
+User-Agent: curl/7.47.0
+Authorization: A2A $apikey
+Accept: application/json
+Content-Length: 6
+ 
+ignore
+
+Q
+EOF
+        )
+        fi
+    else
+        local response=$(curl -s -k --key $pkeyfile --cert $certfile --pass $pass -X $method -H 'Accept: application/json' \
+                              -H 'Content-type: application/json' -H "Authorization: A2A $apikey" \
+                              -d @- "https://$appliance/service/a2a/v$version/$relurl" <<EOF
+$body
+EOF
+        )
+        if [ -z "$response" ]; then
+            body="$(echo -e "${body}" | tr -d '[:space:]')"
+            local bodylen=$(echo -n "${body}" | wc -m)
+            # There is a bug in some Debian-based platforms with curl linked to GnuTLS where it doesn't properly
+            # ignore certificate errors when using client certificate authentication. This works around that
+            # problem by calling OpenSSL directly and manually formulating an HTTP request.
+            response=$(cat <<EOF | openssl s_client -connect $appliance:443 -ign_eof -key $pkeyfile -cert $certfile -pass pass:$pass 2>&1
+POST /service/a2a/v$version/$relurl HTTP/1.1
+Host: $appliance
+User-Agent: curl/7.47.0
+Authorization: A2A $apikey
+Accept: application/json
+Content-type: application/json
+Content-Length: $bodylen
+
+$body
+
+Q
+EOF
+              )
+        fi
+    fi
+}

--- a/src/utils/a2a.sh
+++ b/src/utils/a2a.sh
@@ -23,19 +23,17 @@ invoke_a2a_method()
             # There is a bug in some Debian-based platforms with curl linked to GnuTLS where it doesn't properly
             # ignore certificate errors when using client certificate authentication. This works around that
             # problem by calling OpenSSL directly and manually formulating an HTTP request.
-            response=$(cat <<EOF | openssl s_client -connect $appliance:443 -ign_eof -key $pkeyfile -cert $certfile -pass pass:$pass 2>&1
+            response=$(cat <<EOF | openssl s_client -connect $appliance:443 -quiet -crlf -key $pkeyfile -cert $certfile -pass pass:$pass 2>&1
 $method /service/a2a/v$version/$relurl HTTP/1.1
 Host: $appliance
 User-Agent: curl/7.47.0
 Authorization: A2A $apikey
 Accept: application/json
-Content-Length: 6
- 
-ignore
+Connection: close
 
-Q
 EOF
-        )
+            )
+            echo "$response" | sed -n '/read:errno/,$p' | sed -e 's/\(.*\)read\:errno\=.*/\1/'
         fi
     else
         local response=$(curl -s -k --key $pkeyfile --cert $certfile --pass $pass -X $method -H 'Accept: application/json' \
@@ -50,20 +48,20 @@ EOF
             # There is a bug in some Debian-based platforms with curl linked to GnuTLS where it doesn't properly
             # ignore certificate errors when using client certificate authentication. This works around that
             # problem by calling OpenSSL directly and manually formulating an HTTP request.
-            response=$(cat <<EOF | openssl s_client -connect $appliance:443 -ign_eof -key $pkeyfile -cert $certfile -pass pass:$pass 2>&1
+            response=$(cat <<EOF | openssl s_client -connect $appliance:443 -quiet -crlf -key $pkeyfile -cert $certfile -pass pass:$pass 2>&1
 POST /service/a2a/v$version/$relurl HTTP/1.1
 Host: $appliance
 User-Agent: curl/7.47.0
 Authorization: A2A $apikey
 Accept: application/json
+Connection: close
 Content-type: application/json
 Content-Length: $bodylen
 
 $body
-
-Q
 EOF
-              )
+            )
+            echo "$response" | sed -n '/read:errno/,$p' | sed -e 's/\(.*\)read\:errno\=.*/\1/'
         fi
     fi
 }

--- a/src/utils/loginfile.sh
+++ b/src/utils/loginfile.sh
@@ -20,7 +20,6 @@ use_login_file()
     if [ "$Provider" = "certificate" ]; then
         Cert=$(read_from_login_file Cert)
         PKey=$(read_from_login_file PKey)
-        Pass=$(read_from_login_file Pass)
     fi
 }
 


### PR DESCRIPTION
Cleaned up some code for certificate authentication
Fixed a bug with HTTP 2.0 not working for certificates with curl
Fixed the workaround for Ubuntu GnuTLS not honoring certificate ignore flag