### PR TITLE
Fix get-a2a-password.sh on Ubuntu

### DIFF
--- a/src/get-a2a-password.sh
+++ b/src/get-a2a-password.sh
@@ -3,8 +3,8 @@
 print_usage()
 {
     cat <<EOF
-USAGE: get-a2a-password.sh [-h]
-       get-a2a-password.sh [-a appliance] [-v version] [-c file] [-k file] [-A apikey] [-p]
+USAGE: $1 [-h]
+       $1 [-a appliance] [-v version] [-c file] [-k file] [-A apikey] [-p]
 
   -h  Show help and exit
   -a  Network address of the appliance
@@ -74,7 +74,7 @@ while getopts ":a:v:c:k:A:ph" opt; do
         ApiKey=$OPTARG
         ;;
     h)
-        print_usage
+        print_usage $0
         ;;
     esac
 done

--- a/src/utils/a2a.sh
+++ b/src/utils/a2a.sh
@@ -22,7 +22,7 @@ invoke_a2a_method()
         local response=$(curl -s -k --key $pkeyfile --cert $certfile --pass $pass -X $method $http11flag -H 'Accept: application/json' \
                               -H "Authorization: A2A $apikey" "https://$appliance/service/a2a/v$version/$relurl"
         )
-        if [ ! -z "$response" ]; then
+        if [ ! -z "$response" -a ! -z "$(echo $response | jq '.Codes // empty')" ]; then
             echo "$response"
         else
             # There is a bug in some Debian-based platforms with curl linked to GnuTLS where it doesn't properly


### PR DESCRIPTION
There are some major issues with the way that GnuTLS works with
curl, but the Ubuntu folks don't seem to care.  Somehow when using
curl compiled with GnuTLS -k means ignore SSL validation except
when using a client certificate, then the GnuTLS implementation
burns you with validation anyway, even if you have -k.