### PR TITLE
Add the -O option for RedHat Enterprise Linux 7 A2A cred retrieval

### DIFF
--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,6 +1,6 @@
 variables:
   - name: version
-    value: "6.10"
+    value: "6.11"
   - name: isPrerelease
     value: ${{ true }}
   - name: shouldPublishDocker

--- a/samples/event-handling/a2a-event-handling/setup.sh
+++ b/samples/event-handling/a2a-event-handling/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing and manipulating responses."
     exit 1
 fi

--- a/samples/event-handling/generic-event-handling/generic-event-handler.sh
+++ b/samples/event-handling/generic-event-handling/generic-event-handler.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires the jq utility for parsing JSON response data from Safeguard"
     exit 1
 fi

--- a/samples/import-assets-from-tpam/import-assets-from-tpam.sh
+++ b/samples/import-assets-from-tpam/import-assets-from-tpam.sh
@@ -74,7 +74,7 @@ while getopts ":t:a:T:I:P:h" opt; do
     esac
 done
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires extensive JSON parsing, so you must download and install jq to use it."
     exit 1
 fi
@@ -116,15 +116,15 @@ TpamJsonFiltered=$(echo $TpamJson \
 SgJsonPre=$(echo $TpamJsonFiltered \
            | jq '.[] | with_entries(
                  if (.key == "SystemName") then
-                     .key |= "Name" 
+                     .key |= "Name"
                  elif (.key == "PortNumber") then
                      .key |= "ConnectionProperties"
                  elif (.key == "PlatformName") then
-                     .key |= "PlatformId" 
+                     .key |= "PlatformId"
                  else . end )' \
            | jq 'with_entries(
                  if ((.key == "ConnectionProperties") and (.value == null)) then
-                     .value |= { ServiceAccountCredentialType: "None" } 
+                     .value |= { ServiceAccountCredentialType: "None" }
                  elif (.key == "ConnectionProperties") then
                      .value |= { ServiceAccountCredentialType: "None", Port: . }
                  else . end )' | jq -s .)

--- a/src/edit-access-request.sh
+++ b/src/edit-access-request.sh
@@ -26,7 +26,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing and manipulating responses."
     exit 1
 fi

--- a/src/get-a2a-password.sh
+++ b/src/get-a2a-password.sh
@@ -96,7 +96,7 @@ require_args
 
 ATTRFILTER='cat'
 ERRORFILTER='cat'
-if [ ! -z "$(which jq)" ]; then
+if [ ! -z "$(which jq 2> /dev/null)" ]; then
     ERRORFILTER='jq .'
     if $Raw; then
         ATTRFILTER='jq --raw-output .'

--- a/src/get-a2a-privatekey.sh
+++ b/src/get-a2a-privatekey.sh
@@ -109,7 +109,7 @@ require_args
 
 ATTRFILTER='cat'
 ERRORFILTER='cat'
-if [ ! -z "$(which jq)" ]; then
+if [ ! -z "$(which jq 2> /dev/null)" ]; then
     ERRORFILTER='jq .'
     if $Raw; then
         ATTRFILTER='jq --raw-output .'

--- a/src/get-a2a-privatekey.sh
+++ b/src/get-a2a-privatekey.sh
@@ -4,7 +4,7 @@ print_usage()
 {
     cat <<EOF
 USAGE: get-a2a-privatekey.sh [-h]
-       get-a2a-privatekey.sh [-a appliance] [-B cabundle] [-v version] [-c file] [-k file] [-A apikey] [-F format] [-p] [-r]
+       get-a2a-privatekey.sh [-a appliance] [-B cabundle] [-v version] [-c file] [-k file] [-A apikey] [-F format] [-O] [-p] [-r]
 
   -h  Show help and exit
   -a  Network address of the appliance
@@ -13,8 +13,9 @@ USAGE: get-a2a-privatekey.sh [-h]
   -c  File containing client certificate
   -k  File containing client private key
   -A  A2A API token identifying the account
+  -O  Use openssl s_client instead of curl for TLS client authentication problems
   -p  Read certificate password from stdin
-  -r  Raw output, i.e. remove quotes & interpret escape chars from JSON string to get just the private key
+  -r  Raw output, i.e. remove quotes & interpret escape chars from JSON string to get just the private key (requires jq)
   -F  Private key format (default: OpenSsh)
       OpenSsh: OpenSSH legacy PEM format
       Ssh2: Tectia format for use with tools from SSH.com
@@ -40,6 +41,7 @@ Raw=false
 KeyFormat=OpenSsh
 PassStdin=
 Pass=
+UseOpenSslSclient=false
 
 . "$ScriptDir/utils/loginfile.sh"
 . "$ScriptDir/utils/a2a.sh"
@@ -65,7 +67,7 @@ require_args()
     fi
 }
 
-while getopts ":a:B:v:c:k:A:F:prh" opt; do
+while getopts ":a:B:v:c:k:A:F:pOrh" opt; do
     case $opt in
     a)
         Appliance=$OPTARG
@@ -87,6 +89,9 @@ while getopts ":a:B:v:c:k:A:F:prh" opt; do
         ;;
     A)
         ApiKey=$OPTARG
+        ;;
+    O)
+        UseOpenSslSclient=true
         ;;
     r)
         Raw=true
@@ -118,7 +123,7 @@ if [ ! -z "$(which jq 2> /dev/null)" ]; then
     fi
 fi
 
-Result=$(invoke_a2a_method "$Appliance" "$CABundleArg" "$Cert" "$PKey" "$Pass" "$ApiKey" a2a GET "Credentials?type=PrivateKey&keyFormat=$KeyFormat" $Version)
+Result=$(invoke_a2a_method "$Appliance" "$CABundleArg" "$Cert" "$PKey" "$Pass" "$ApiKey" a2a GET "Credentials?type=PrivateKey&keyFormat=$KeyFormat" $Version $UseOpenSslSclient)
 echo $Result | jq . > /dev/null 2>&1
 if [ $? -ne 0 ]; then
     echo $Result

--- a/src/get-a2a-retrievable-account.sh
+++ b/src/get-a2a-retrievable-account.sh
@@ -22,6 +22,10 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+if [ -z "$(which jq)" ]; then
+    >&2 echo "This script requires jq for parsing and manipulating responses."
+    exit 1
+fi
 
 Appliance=
 CABundleArg=
@@ -82,11 +86,6 @@ while getopts ":a:B:v:c:k:A:prh" opt; do
 done
 
 require_args
-
-if [ -z "$(which jq 2> /dev/null)" ]; then
-    >&2 echo "This script requires jq for parsing and manipulating responses."
-    exit 1
-fi
 
 Registrations=$(invoke_a2a_method "$Appliance" "$CABundleArg" "$Cert" "$PKey" "$Pass" "NONE" core GET "A2ARegistrations" $Version "")
 echo $Registrations | jq -r '.[] | [.Id, .AppName, .Description // "", .Disabled, .CertificateUserId, .CertificateUser, .CertificateUserThumbPrint] | @tsv' |

--- a/src/get-a2a-retrievable-account.sh
+++ b/src/get-a2a-retrievable-account.sh
@@ -83,7 +83,7 @@ done
 
 require_args
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing and manipulating responses."
     exit 1
 fi

--- a/src/get-access-request.sh
+++ b/src/get-access-request.sh
@@ -22,7 +22,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing and manipulating responses."
     exit 1
 fi

--- a/src/get-actionable-request.sh
+++ b/src/get-actionable-request.sh
@@ -11,7 +11,7 @@ USAGE: get-actionable-request.sh [-h]
   -a  Network address of the appliance
   -t  Safeguard access token
   -v  Web API Version: 3 is default
-  -r  Request role (e.g. Admin, Approver, Requester, Reviewer) 
+  -r  Request role (e.g. Admin, Approver, Requester, Reviewer)
   -F  Full JSON output
 
 Get an access request or all access requests via the Web API that are open that
@@ -79,7 +79,7 @@ require_args
 
 ATTRFILTER='cat'
 ERRORFILTER='cat'
-if [ ! -z "$(which jq)" ]; then
+if [ ! -z "$(which jq 2> /dev/null)" ]; then
     ERRORFILTER='jq .'
     if $FullOutput; then
         ATTRFILTER='jq .'

--- a/src/get-event.sh
+++ b/src/get-event.sh
@@ -19,7 +19,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing between requests."
     exit 1
 fi

--- a/src/get-requestable-account.sh
+++ b/src/get-requestable-account.sh
@@ -21,7 +21,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing between requests."
     exit 1
 fi

--- a/src/get-trusted-ca-bundle.sh
+++ b/src/get-trusted-ca-bundle.sh
@@ -20,7 +20,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing and manipulating responses."
     exit 1
 fi

--- a/src/handle-a2a-password-event.sh
+++ b/src/handle-a2a-password-event.sh
@@ -138,7 +138,7 @@ require_args
 require_prereqs
 
 
-AcctPass=$("$ScriptDir/get-a2a-password.sh" -a $Appliance -v $Version -c $Cert -k $PKey -A $ApiKey -p <<< $Pass | jq -c -r .)
+AcctPass=$("$ScriptDir/get-a2a-password.sh" -a $Appliance -v $Version -c $Cert -k $PKey -A $ApiKey -p $OpenSslSclientFlag <<< $Pass | jq -c -r .)
 Error=$(echo $AcctPass | jq .Code 2> /dev/null)
 if [ ! -z "$Error" -o -z "$AcctPass" ]; then
     >&2 echo "Unable to fetch initial password from A2A service"
@@ -173,7 +173,7 @@ while true; do
         backoff_wait
     fi
     if [ ! -z "$Output" ]; then
-        AcctPass=$("$ScriptDir/get-a2a-password.sh" -a $Appliance -v $Version -c $Cert -k $PKey -A $ApiKey -p <<< $Pass | jq -c -r .)
+        AcctPass=$("$ScriptDir/get-a2a-password.sh" -a $Appliance -v $Version -c $Cert -k $PKey -A $ApiKey -p $OpenSslSclientFlag <<< $Pass | jq -c -r .)
         Error=$(echo $AcctPass | jq .Code 2> /dev/null)
         if [ ! -z "$Error" -o -z "$AcctPass" ]; then
             >&2 echo "Unable to fetch initial password from A2A service"

--- a/src/handle-a2a-password-event.sh
+++ b/src/handle-a2a-password-event.sh
@@ -75,7 +75,7 @@ require_args()
 
 require_prereqs()
 {
-    if [ -z "$(which jq)" ]; then
+    if [ -z "$(which jq 2> /dev/null)" ]; then
         >&2 echo "This script requires the jq utility for parsing JSON response data from Safeguard"
         exit 1
     fi

--- a/src/handle-event.sh
+++ b/src/handle-event.sh
@@ -22,7 +22,7 @@ USAGE: handle-event.sh [-h]
   -S  Script to execute when the event occurs
 
 Connect to SignalR using the Safeguard event service via a Safeguard access token
-and execute a provided script (handler script) each time an event occurs passing 
+and execute a provided script (handler script) each time an event occurs passing
 the details of the event as a JSON object string to stdin.  The handler script will
 actually be passed four lines of text:
 
@@ -80,7 +80,7 @@ require_args()
 
 require_prereqs()
 {
-    if [ -z "$(which jq)" ]; then
+    if [ -z "$(which jq 2> /dev/null)" ]; then
         >&2 echo "This script requires the jq utility for parsing JSON response data from Safeguard"
         exit 1
     fi
@@ -250,7 +250,7 @@ while true; do
             wait $listener_PID
             unset listener_PID
         fi
-        coproc listener { 
+        coproc listener {
             "$ScriptDir/listen-for-event.sh" -a $Appliance -T <<< $AccessToken 2> /dev/null | \
                 jq --unbuffered -c ".arguments[]? | select(.Name==\"$EventName\") | .Data?" 2> /dev/null
         }

--- a/src/install-license.sh
+++ b/src/install-license.sh
@@ -22,7 +22,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing between requests."
     exit 1
 fi

--- a/src/install-ssl-certificate.sh
+++ b/src/install-ssl-certificate.sh
@@ -23,7 +23,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing between requests."
     exit 1
 fi

--- a/src/invoke-safeguard-method.sh
+++ b/src/invoke-safeguard-method.sh
@@ -29,7 +29,7 @@ USAGE: invoke-safeguard-method.sh [-h]
 
 Create a login file using connect-safeguard.sh for convenience. A login file is
 required in order to use certificate authentication. If a login file is not used
-connect-safeguard.sh will be called to create one. You may also use the -n option for 
+connect-safeguard.sh will be called to create one. You may also use the -n option for
 anonymous authentication or the -a and -t options to specify an access token.
 
 NOTE: Install jq to get pretty-printed JSON output.
@@ -160,7 +160,7 @@ done
 
 PRETTYPRINT='cat'
 if [ "$Accept" = "application/json" ]; then
-    if [ ! -z "$(which jq)" ]; then
+    if [ ! -z "$(which jq 2> /dev/null)" ]; then
         if $FilterNulls; then
             # If we had walk we could replace everything recursively with
             #   walk( if type == "object" then with_entries(select(.value != null)) else . end)

--- a/src/listen-for-a2a-event.sh
+++ b/src/listen-for-a2a-event.sh
@@ -135,7 +135,7 @@ EOF
 }
 
 
-if [ ! -z "`which jq`" ]; then
+if [ ! -z "$(which jq 2> /dev/null)" ]; then
     PRETTYPRINT="jq ."
 else
     PRETTYPRINT="cat"

--- a/src/listen-for-event.sh
+++ b/src/listen-for-event.sh
@@ -45,7 +45,7 @@ get_connection_token()
 }
 
 
-if [ ! -z "`which jq`" ]; then
+if [ ! -z "$(which jq 2> /dev/null)" ]; then
     PRETTYPRINT="jq ."
 else
     PRETTYPRINT="cat"

--- a/src/new-access-request.sh
+++ b/src/new-access-request.sh
@@ -5,7 +5,7 @@ print_usage()
     cat <<EOF
 USAGE: new-access-request.sh [-h]
        new-access-request.sh [-v version] [-s assetid] [-c accountid] [-y accesstype] [-F]
-       new-access-request.sh [-a appliance] [-t accesstoken] [-v version] 
+       new-access-request.sh [-a appliance] [-t accesstoken] [-v version]
                              [-s assetid] [-c accountid] [-y accesstype] [-F]
 
   -h  Show help and exit
@@ -26,7 +26,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing and manipulating responses."
     exit 1
 fi

--- a/src/new-certificate-user.sh
+++ b/src/new-certificate-user.sh
@@ -22,7 +22,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing between requests."
     exit 1
 fi

--- a/src/set-account-password.sh
+++ b/src/set-account-password.sh
@@ -22,7 +22,7 @@ EOF
 
 ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires jq for parsing and manipulating responses."
     exit 1
 fi

--- a/src/show-safeguard-method.sh
+++ b/src/show-safeguard-method.sh
@@ -91,7 +91,7 @@ while getopts ":a:B:v:s:m:U:h" opt; do
     esac
 done
 
-if [ -z "$(which jq)" ]; then
+if [ -z "$(which jq 2> /dev/null)" ]; then
     >&2 echo "This script requires extensive JSON parsing, so you must download and install jq to use it."
     exit 1
 fi
@@ -187,15 +187,15 @@ if [ ! -z "$RelativeUrl" -a ! -z "$Method" ]; then
     if [ -z "$Body" ]; then
         Body='null'
     fi
-    Obj=$(echo $Ops | jq "{ 
-        \"Path\": .key | ltrimstr(\"/v$Version/\"), 
-        \"Method\": \"$Method\", 
+    Obj=$(echo $Ops | jq "{
+        \"Path\": .key | ltrimstr(\"/v$Version/\"),
+        \"Method\": \"$Method\",
         \"Description\": .value.$MethodFilter.summary,
         \"QueryParameters\": [.value.$MethodFilter.parameters[] | select(.in == \"query\") | {
             \"Name\": .name,
             \"Description\": .description,
             \"Type\": .type,
-            \"Required\": .required 
+            \"Required\": .required
         }],
         \"PathParameters\": [.value.$MethodFilter.parameters[] | select(.in == \"path\") | {
             \"Name\": .name,

--- a/src/utils/a2a.sh
+++ b/src/utils/a2a.sh
@@ -38,7 +38,7 @@ EOF
 ) "https://$appliance/service/$service/v$version/$relurl"
        )
         if [ -z "$(which jq 2> /dev/null)" ]; then
-            error=$(echo $response | grep ".Code")
+            error=$(echo $response | grep '"Code":60108')
         else
             error=$(echo $response | jq .Code 2> /dev/null)
         fi

--- a/src/utils/a2a.sh
+++ b/src/utils/a2a.sh
@@ -37,7 +37,11 @@ $apikeyflag
 EOF
 ) "https://$appliance/service/$service/v$version/$relurl"
        )
-        error=$(echo $response | jq .Code 2> /dev/null)
+        if [ -z "$(which jq 2> /dev/null)" ]; then
+            error=$(echo $response | grep ".Code")
+        else
+            error=$(echo $response | jq .Code 2> /dev/null)
+        fi
     fi
     if [ ! -z "$response" ] && [ -z "$error" -o "$error" = "null" ]; then
         echo "$response"

--- a/src/utils/a2a.sh
+++ b/src/utils/a2a.sh
@@ -3,24 +3,28 @@
 # It shouldn't be called directly.
 invoke_a2a_method()
 {
-    local appliance=$1 ; shift
-    local cabundlearg=$1 ; shift
-    local certfile=$1 ; shift
-    local pkeyfile=$1 ; shift
-    local pass=$1 ; shift
-    local apikey=$1 ; shift
-    local service=$1 ; shift
-    local method=$1 ; shift
+    local appliance=$1 ; shift       #1
+    local cabundlearg=$1 ; shift     #2
+    local certfile=$1 ; shift        #3
+    local pkeyfile=$1 ; shift        #4
+    local pass=$1 ; shift            #5
+    local apikey=$1 ; shift          #6
+    local service=$1 ; shift         #7
+    local method=$1 ; shift          #8
     method=$(echo "$method" | tr '[:lower:]' '[:upper:]')
-    local relurl=$1 ; shift
-    local version=$1 ; shift
+    local relurl=$1 ; shift          #9
+    local version=$1 ; shift         #10
+    local usesclient=$1 ; shift      #11
 
-    apikeyflag="-H \"Authorization: A2A $apikey\""
+    local apikeyflag="-H \"Authorization: A2A $apikey\""
+    local response=""
+    local error=""
 
-    if [ $(curl --version | grep "libcurl" | sed -e 's,curl [0-9]*\.\([0-9]*\).* (.*,\1,') -ge 33 ]; then
-        http11flag='--http1.1'
-    fi
-    local response=$(curl -K <(cat <<EOF
+    if ! $usesclient; then
+        if [ $(curl --version | grep "libcurl" | sed -e 's,curl [0-9]*\.\([0-9]*\).* (.*,\1,') -ge 33 ]; then
+            http11flag='--http1.1'
+        fi
+        response=$(curl -K <(cat <<EOF
 -s
 $cabundlearg
 --key $pkeyfile
@@ -33,7 +37,8 @@ $apikeyflag
 EOF
 ) "https://$appliance/service/$service/v$version/$relurl"
        )
-    local error=$(echo $response | jq .Code 2> /dev/null)
+        error=$(echo $response | jq .Code 2> /dev/null)
+    fi
     if [ ! -z "$response" ] && [ -z "$error" -o "$error" = "null" ]; then
         echo "$response"
     else

--- a/src/utils/loginfile.sh
+++ b/src/utils/loginfile.sh
@@ -52,7 +52,7 @@ require_login_args()
 
 query_providers()
 {
-    if [ ! -z "$(which jq)" ]; then
+    if [ ! -z "$(which jq 2> /dev/null)" ]; then
         GetPrimaryProvidersRelativeURL="RSTS/UserLogin/LoginController?response_type=token&redirect_uri=urn:InstalledApplication&loginRequestStep=1"
         Providers=$(curl -s $CABundleArg -X POST -H "Accept: application/json" "https://$Appliance/$GetPrimaryProvidersRelativeURL" \
                          -d 'RelayState=' | jq -c '.Providers | del(.[].ForgotPasswordUrl)')
@@ -76,7 +76,7 @@ require_connect_args()
     if [ -z "$Appliance" ]; then
         read -p "Appliance Network Address: " Appliance
     fi
-    if [ ! -z "$(which jq)" ]; then
+    if [ ! -z "$(which jq 2> /dev/null)" ]; then
         query_providers
     fi
     ProviderPrompt=$(echo $Providers | jq '.|del(.[] | select(.Id == "local"))|del(.[] |select(.Id == "certificate"))|.[]|"\(.Id) [\(.DisplayName)],"' | xargs echo -n | sed 's/.$//')


### PR DESCRIPTION
RHEL 7 has the problem where curl is linked to an SSL implementation that doesn't do client certificate authentication correctly.  In order work around this we can use openssl s_client instead.  Callers can now pass the -O option to manually request this implementation rather than curl when calling get-a2a-password.sh or get-a2a-privatekey.sh.