### PR TITLE
Release version 7.4 now that SPP is GA

### DIFF
--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -2,6 +2,6 @@ variables:
   - name: version
     value: "7.4"
   - name: isPrerelease
-    value: ${{ true }}
+    value: ${{ false }}
   - name: shouldPublishDocker
     value: $[ eq( variables.isPrerelease, false ) ]


### PR DESCRIPTION
This is the final PR to finalized the 7.4 release of safeguard-bash to coincide with SPP 7.4 GA.  I'm assuming I can merge the 7.4 branch into master branch after this PR is approved.  Please let me know otherwise.