### PR TITLE
New feature to support PKCE noninteractive login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,10 @@ The test framework (`test/framework.sh`) provides:
   `sg_assert_contains`, `sg_skip`
 - **Cleanup registration**: `sg_register_cleanup` (LIFO execution order)
 - **Suite lifecycle**: Setup → Execute → Registered Cleanups (LIFO) → Suite Cleanup
-- **Helpers**: `sg_connect`, `sg_disconnect`, `sg_invoke`
+- **Helpers**: `sg_connect`, `sg_connect_pkce`, `sg_disconnect`, `sg_invoke`
+- **ROG management**: `sg_ensure_rog_enabled`, `sg_restore_rog` — the test
+  runner uses these to automatically enable the Resource Owner grant type
+  before tests and restore the original setting afterward
 
 ### Writing a Test Suite
 
@@ -215,7 +218,7 @@ The current baseline when all suites pass:
 
 ```
 Suites: 6 (0 failed)
-Tests:  94 passed, 0 failed, 0 skipped
+Tests:  102 passed, 0 failed, 0 skipped
 ```
 
 | Suite           | Tests | Description                                       |
@@ -223,7 +226,7 @@ Tests:  94 passed, 0 failed, 0 skipped
 | A2A             | 18    | Full A2A workflow: cert, registration, retrieval   |
 | Asset Accounts  | 17    | Account CRUD, passwords, edit, filter              |
 | Assets          | 17    | Asset CRUD, platform validation, edit, filter      |
-| Connect & Core  | 9     | Connect, login file, API calls, disconnect         |
+| Connect & Core  | 16    | Connect, PKCE, login file, API calls, disconnect   |
 | Platforms       | 17    | Built-in platform validation (Windows, Linux)      |
 | Users           | 16    | User CRUD, roles, edit, filter, delete             |
 
@@ -299,6 +302,8 @@ These flags are consistent across most scripts:
 | `-k` | Client private key file             |
 | `-t` | Access token                        |
 | `-p` | Read password from stdin            |
+| `-P` | Use PKCE authentication (connect-safeguard.sh) |
+| `-S` | Secondary password / MFA code (with `-P`) |
 
 ### Error Handling
 
@@ -332,8 +337,9 @@ fi
 Scripts share authentication state through `$HOME/.safeguard_login`, a
 key=value file created with `umask 0077` (readable only by owner).
 
-The file stores: `Appliance`, `Provider`, `AccessToken`, `CABundleArg`, and
-optionally `Cert`/`PKey` for certificate auth.
+The file stores: `Appliance`, `Provider`, `AccessToken`, `CABundleArg`,
+optionally `Cert`/`PKey` for certificate auth, and `Pkce=true` when PKCE
+authentication was used.
 
 Most scripts call `use_login_file()` from `utils/loginfile.sh`, which
 auto-invokes `connect-safeguard.sh` if no login file exists.
@@ -388,13 +394,45 @@ appliances.
 ### Authentication Methods
 
 1. **Password (Resource Owner Grant)** — username + password to a local or
-   directory identity provider
+   directory identity provider. Requires the Resource Owner grant type to be
+   enabled on the appliance (see below).
 2. **Certificate** — client certificate + private key, provider set to
    `certificate`
-3. **PKCE** — browser-based OAuth2 flow (not supported in bash scripts)
+3. **PKCE (Proof Key for Code Exchange)** — non-interactive OAuth2 flow that
+   programmatically simulates the browser-based login without launching a
+   browser. Use `connect-safeguard.sh -P`. This does **not** require the
+   Resource Owner grant type to be enabled, making it the most reliable
+   connection method.
 
-For scripting and testing, password authentication with a local admin account
-is the standard approach.
+For scripting and testing, PKCE authentication (`-P`) with a local admin
+account is the recommended approach because it works regardless of the
+appliance's grant type configuration. Password authentication is also
+supported but requires the Resource Owner grant type to be enabled.
+
+### Resource Owner Grant Type
+
+The Resource Owner password grant (`grant_type=password`) may be disabled on
+the appliance by default. The appliance setting "Allowed OAuth2 Grant Types"
+controls which grant types are permitted.
+
+To check/modify this setting programmatically:
+
+```bash
+# Read current grant types (requires an active session)
+invoke-safeguard-method.sh -s core -m GET -U "Settings" \
+    | jq '.[] | select(.Name=="Allowed OAuth2 Grant Types") | .Value'
+
+# Enable Resource Owner grant (note: URL-encode the setting name)
+invoke-safeguard-method.sh -s core -m PUT \
+    -U "Settings/Allowed%20OAuth2%20Grant%20Types" \
+    -b '{"Value":"ResourceOwner"}'
+```
+
+**Important:** The setting name contains spaces and must be URL-encoded
+(`%20`) in the URL path when using `invoke-safeguard-method.sh`.
+
+The test runner automatically handles this: it connects via PKCE, enables
+ROG if needed, runs all suites, then restores the original setting.
 
 ### SSL/TLS
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,29 @@ self-contained CLI command that wraps one or more Safeguard API operations.
 The scripts are designed to run standalone on any system with bash, curl, and
 jq, or inside an Alpine-based Docker container.
 
+### Reference: safeguard-ps (PowerShell SDK)
+
+The **[OneIdentity/safeguard-ps](https://github.com/OneIdentity/safeguard-ps)**
+repository is the PowerShell equivalent of safeguard-bash. It covers the same
+Safeguard API but is significantly more mature and feature-rich.
+
+When working on safeguard-bash, consult safeguard-ps to:
+
+- **Find missing functionality** — safeguard-ps implements many commands that
+  safeguard-bash does not yet have. Look for PowerShell cmdlets that have no
+  corresponding bash script and consider adding them.
+- **Compare implementation techniques** — see how safeguard-ps handles error
+  checking, parameter validation, pagination, filtering, and edge cases.
+- **Validate API usage patterns** — safeguard-ps is a good reference for
+  correct API endpoint usage, required fields, and expected response formats.
+- **Adopt testing patterns** — safeguard-ps has a comprehensive test suite
+  (in its `test/` directory) that demonstrates thorough assertion strategies
+  and cleanup practices. The "Writing Strong Assertions" section below was
+  adapted from safeguard-ps.
+
+When proposing new scripts or features, check safeguard-ps first to see if an
+equivalent exists and use it as a guide for the bash implementation.
+
 ---
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -79,8 +79,23 @@ Just use Docker, and you won't have to worry about prerequisites!
 
 ## Getting Started
 Once safeguard-bash is installed, you can begin by running `connect-safeguard.sh`.
-Authentication in Safeguard is based on OAuth2 and `connect-safeguard.sh` uses
-the Resource Owner Grant of OAuth2.
+Authentication in Safeguard is based on OAuth2. The recommended connection method
+is PKCE (Proof Key for Code Exchange), which works regardless of the appliance's
+grant type configuration:
+
+```Bash
+$ connect-safeguard.sh -a 10.5.32.162 -i local -u Admin -P
+Password:
+A login file has been created.
+```
+
+The `-P` flag uses PKCE authentication, which programmatically simulates the
+browser-based OAuth2 flow without launching a browser. This is the most reliable
+connection method because it does not require the Resource Owner password grant
+type to be enabled on the appliance.
+
+If your appliance has the Resource Owner grant type enabled, you can also use
+direct password authentication (the classic method):
 
 ```Bash
 $ connect-safeguard.sh
@@ -90,6 +105,10 @@ Appliance Login: Admin
 Password:
 A login file has been created.
 ```
+
+> **Note:** Starting with newer Safeguard versions, the Resource Owner password
+> grant type may be disabled by default. If you receive authentication errors
+> using the classic method, use `-P` for PKCE authentication instead.
 
 The `connect-safeguard.sh` script will create a login file that includes
 your access token and connection information.  This makes it easier to call

--- a/src/connect-safeguard.sh
+++ b/src/connect-safeguard.sh
@@ -6,6 +6,7 @@ print_usage()
 USAGE: connect-safeguard.sh [-h]
        connect-safeguard.sh [-a appliance] [-B cabundle] [-v version] [-i provider] [-u user] [-p] [-X]
        connect-safeguard.sh [-a appliance] [-B cabundle] [-v version] -i certificate [-c file] [-k file] [-p] [-X]
+       connect-safeguard.sh [-a appliance] [-B cabundle] [-v version] [-i provider] [-u user] [-p] -P [-S] [-X]
 
   -h  Show help and exit
   -a  Network address of the appliance
@@ -16,6 +17,12 @@ USAGE: connect-safeguard.sh [-h]
   -c  File containing client certificate
   -k  File containing client private key
   -p  Read Safeguard or certificate password from stdin
+  -P  Use PKCE (Proof Key for Code Exchange) non-interactive authentication.
+      This programmatically simulates the browser-based OAuth2/PKCE flow without
+      launching a browser, which does not require the Resource Owner password grant
+      type to be enabled on the appliance.
+  -S  Secondary password or MFA code (only used with -P when the identity
+      provider requires a second factor, will prompt if not provided)
   -X  Do NOT generate login file for use in other scripts
 
 The invoke-safeguard-method.sh and listen-for-event.sh scripts will attempt to use
@@ -42,6 +49,8 @@ User=
 Cert=
 PKey=
 Pass=
+Pkce=false
+SecondaryPass=
 StsAccessToken=
 AccessToken=
 StoreLoginFile=true
@@ -126,6 +135,230 @@ EOF
     fi
 }
 
+base64url_encode()
+{
+    openssl enc -base64 -A | tr -d '=' | tr '+/' '-_'
+}
+
+urlencode()
+{
+    if [ ! -z "$(which jq 2> /dev/null)" ]; then
+        printf '%s' "$1" | jq -sRr @uri
+    else
+        local string="$1" encoded="" i c
+        for (( i=0; i<${#string}; i++ )); do
+            c="${string:$i:1}"
+            case "$c" in
+                [a-zA-Z0-9.~_-]) encoded+="$c" ;;
+                *) encoded+=$(printf '%%%02X' "'$c") ;;
+            esac
+        done
+        printf '%s' "$encoded"
+    fi
+}
+
+get_rsts_token_with_pkce()
+{
+    # Generate PKCE code_verifier (60 random bytes, base64url-encoded)
+    local CodeVerifier=$(openssl rand 60 | base64url_encode)
+
+    # Generate PKCE code_challenge (SHA256 of verifier, base64url-encoded)
+    local CodeChallenge=$(printf '%s' "$CodeVerifier" | openssl dgst -sha256 -binary | base64url_encode)
+
+    # Generate CSRF token (32 random bytes, base64url-encoded)
+    local CsrfToken=$(openssl rand 32 | base64url_encode)
+
+    local RedirectUri="urn:InstalledApplication"
+    local EncodedRedirectUri=$(urlencode "$RedirectUri")
+    local PkceBase="https://$Appliance/RSTS/UserLogin/LoginController?response_type=code&code_challenge_method=S256&code_challenge=$CodeChallenge&redirect_uri=$EncodedRedirectUri&loginRequestStep="
+
+    local FormData="directoryComboBox=$Provider&usernameTextbox=$(urlencode "$User")&passwordTextbox=$(urlencode "$Pass")&csrfTokenTextbox=$CsrfToken"
+
+    local CookieFile=$(mktemp)
+    trap "rm -f $CookieFile" RETURN
+
+    # Pre-set CSRF cookie
+    local Now=$(date +%s)
+    local Expiry=$((Now + 3600))
+    printf "%s\tFALSE\t/RSTS\tTRUE\t%s\tCsrfToken\t%s\n" "$Appliance" "$Expiry" "$CsrfToken" > "$CookieFile"
+
+    # Step 1: Initialize rSTS session
+    local StepResponse
+    StepResponse=$(curl -K <(cat <<EOF
+-s
+-S
+$CABundleArg
+-X POST
+-H "Accept: application/json"
+-H "Content-Type: application/x-www-form-urlencoded"
+-b $CookieFile
+-c $CookieFile
+EOF
+) -d "$FormData" "${PkceBase}1")
+    if [ $? -ne 0 ]; then
+        >&2 echo "PKCE: rSTS initialization failed"
+        exit 1
+    fi
+
+    # Step 3: Primary authentication
+    local PrimaryResponse
+    PrimaryResponse=$(curl -K <(cat <<EOF
+-s
+-S
+$CABundleArg
+-X POST
+-H "Accept: application/json"
+-H "Content-Type: application/x-www-form-urlencoded"
+-b $CookieFile
+-c $CookieFile
+EOF
+) -d "$FormData" "${PkceBase}3")
+    if [ $? -ne 0 ]; then
+        >&2 echo "PKCE: rSTS primary authentication failed"
+        exit 1
+    fi
+
+    # Check for secondary authentication requirement
+    local SecondaryProvider
+    if [ ! -z "$(which jq 2> /dev/null)" ]; then
+        SecondaryProvider=$(echo "$PrimaryResponse" | jq -r '.SecondaryProviderID // empty' 2> /dev/null)
+    else
+        SecondaryProvider=$(echo "$PrimaryResponse" | sed -n 's/.*"SecondaryProviderID":"\([^"]*\)".*/\1/p')
+    fi
+
+    if [ ! -z "$SecondaryProvider" ]; then
+        if [ -z "$SecondaryPass" ]; then
+            read -s -p "Secondary Password / MFA Code: " SecondaryPass
+            >&2 echo
+        fi
+
+        # Step 7: Initialize secondary authentication
+        local SecondaryInitResponse
+        SecondaryInitResponse=$(curl -K <(cat <<EOF
+-s
+-S
+$CABundleArg
+-X POST
+-H "Accept: application/json"
+-H "Content-Type: application/x-www-form-urlencoded"
+-b $CookieFile
+-c $CookieFile
+EOF
+) -d "$FormData" "${PkceBase}7")
+        if [ $? -ne 0 ]; then
+            >&2 echo "PKCE: rSTS secondary initialization failed"
+            exit 1
+        fi
+
+        local MfaState=""
+        if [ ! -z "$(which jq 2> /dev/null)" ]; then
+            MfaState=$(echo "$SecondaryInitResponse" | jq -r '.State // empty' 2> /dev/null)
+            local MfaMessage=$(echo "$SecondaryInitResponse" | jq -r '.Message // empty' 2> /dev/null)
+            if [ ! -z "$MfaMessage" ]; then
+                >&2 echo "MFA prompt: $MfaMessage"
+            fi
+        else
+            MfaState=$(echo "$SecondaryInitResponse" | sed -n 's/.*"State":"\([^"]*\)".*/\1/p')
+        fi
+
+        # Step 5: Submit secondary credentials
+        local MfaFormData="$FormData&secondaryLoginTextbox=$(urlencode "$SecondaryPass")&secondaryAuthenticationStateTextbox=$(urlencode "$MfaState")"
+        local MfaResponse MfaHttpCode
+        MfaResponse=$(curl -K <(cat <<EOF
+-s
+-S
+$CABundleArg
+-X POST
+-H "Accept: application/json"
+-H "Content-Type: application/x-www-form-urlencoded"
+-b $CookieFile
+-c $CookieFile
+-w "\n%{http_code}"
+EOF
+) -d "$MfaFormData" "${PkceBase}5")
+        MfaHttpCode=$(echo "$MfaResponse" | tail -1)
+        MfaResponse=$(echo "$MfaResponse" | sed '$d')
+        if [ "$MfaHttpCode" = "203" ]; then
+            >&2 echo "PKCE: Secondary authentication failed"
+            >&2 echo "$MfaResponse"
+            exit 1
+        fi
+        if [ $? -ne 0 ]; then
+            >&2 echo "PKCE: rSTS secondary authentication failed"
+            exit 1
+        fi
+    fi
+
+    # Step 6: Generate claims and get authorization code
+    local ClaimsResponse
+    ClaimsResponse=$(curl -K <(cat <<EOF
+-s
+-S
+$CABundleArg
+-X POST
+-H "Accept: application/json"
+-H "Content-Type: application/x-www-form-urlencoded"
+-b $CookieFile
+-c $CookieFile
+EOF
+) -d "$FormData" "${PkceBase}6")
+    if [ $? -ne 0 ]; then
+        >&2 echo "PKCE: rSTS claims generation failed"
+        exit 1
+    fi
+
+    # Extract authorization code from RelyingPartyUrl
+    local RelyingPartyUrl AuthorizationCode
+    if [ ! -z "$(which jq 2> /dev/null)" ]; then
+        RelyingPartyUrl=$(echo "$ClaimsResponse" | jq -r '.RelyingPartyUrl // empty' 2> /dev/null)
+    else
+        RelyingPartyUrl=$(echo "$ClaimsResponse" | sed -n 's/.*"RelyingPartyUrl":"\([^"]*\)".*/\1/p')
+    fi
+
+    if [ -z "$RelyingPartyUrl" ]; then
+        >&2 echo "PKCE: rSTS response did not contain a RelyingPartyUrl"
+        >&2 echo "$ClaimsResponse"
+        exit 1
+    fi
+
+    AuthorizationCode=$(echo "$RelyingPartyUrl" | sed -n 's/.*[?&]code=\([^&]*\).*/\1/p')
+    if [ -z "$AuthorizationCode" ]; then
+        >&2 echo "PKCE: rSTS response did not contain an authorization code"
+        >&2 echo "$RelyingPartyUrl"
+        exit 1
+    fi
+
+    # Exchange authorization code for RSTS access token
+    StsResponse=$(curl -K <(cat <<EOF
+-s
+-S
+$CABundleArg
+-X POST
+-H "Accept: application/json"
+-H "Content-type: application/json"
+EOF
+) -d @- "https://$Appliance/RSTS/oauth2/token" <<EOF
+{
+    "grant_type": "authorization_code",
+    "redirect_uri": "$RedirectUri",
+    "code": "$AuthorizationCode",
+    "code_verifier": "$CodeVerifier"
+}
+EOF
+    )
+    if [ $? -ne 0 ]; then
+        >&2 echo "PKCE: Failed to exchange authorization code for RSTS token"
+        >&2 echo "$StsResponse"
+        exit 1
+    fi
+
+    StsAccessToken=$(echo $StsResponse | sed -n 's/.*"access_token":"\([-0-9A-Za-z_\.]*\)",.*/\1/p')
+    if [ -z "$StsAccessToken" ]; then
+        >&2 echo -e "PKCE: Failed to get access token from RSTS\n$StsResponse"
+        exit 1
+    fi
+}
+
 get_safeguard_token()
 {
     if [ ! -z "$StsAccessToken" ]; then
@@ -170,7 +403,7 @@ EOF
 }
 
 
-while getopts ":a:B:v:i:u:c:k:phX" opt; do
+while getopts ":a:B:v:i:u:c:k:phPS:X" opt; do
     case $opt in
     a)
         Appliance=$OPTARG
@@ -197,6 +430,12 @@ while getopts ":a:B:v:i:u:c:k:phX" opt; do
         # read password from stdin before doing anything
         read -s Pass
         ;;
+    P)
+        Pkce=true
+        ;;
+    S)
+        SecondaryPass=$OPTARG
+        ;;
     X)
         StoreLoginFile=false
         ;;
@@ -210,7 +449,15 @@ require_connect_args
 
 Scope="rsts:sts:primaryproviderid:$Provider"
 
-get_rsts_token
+if $Pkce; then
+    if [ "$Provider" = "certificate" ]; then
+        >&2 echo "PKCE authentication cannot be used with certificate provider"
+        exit 1
+    fi
+    get_rsts_token_with_pkce
+else
+    get_rsts_token
+fi
 
 get_safeguard_token
 

--- a/src/connect-safeguard.sh
+++ b/src/connect-safeguard.sh
@@ -481,6 +481,11 @@ Cert=$Cert
 PKey=$PKey
 EOF
     fi
+    if $Pkce; then
+        cat <<EOF >> $LoginFile
+Pkce=true
+EOF
+    fi
     umask $OldUmask
     >&2 echo "A login file has been created."
 else

--- a/test/framework.sh
+++ b/test/framework.sh
@@ -296,6 +296,14 @@ sg_connect()
         -a "$TestAppliance" -i local -u "$TestUser" -v "$TestVersion" -p 2>/dev/null
 }
 
+# Connect to the test appliance using PKCE and create a login file.
+# Uses the global TestAppliance, TestUser, TestPassword, TestVersion.
+sg_connect_pkce()
+{
+    echo "$TestPassword" | "$ScriptDir/../src/connect-safeguard.sh" \
+        -a "$TestAppliance" -i local -u "$TestUser" -v "$TestVersion" -P -p 2>/dev/null
+}
+
 # Disconnect from the test appliance.
 sg_disconnect()
 {

--- a/test/framework.sh
+++ b/test/framework.sh
@@ -316,3 +316,95 @@ sg_invoke()
 {
     "$ScriptDir/../src/invoke-safeguard-method.sh" "$@" 2>/dev/null
 }
+
+# --- Resource Owner Grant (ROG) Management ---
+# The Safeguard "Allowed OAuth2 Grant Types" setting controls whether
+# password-based (Resource Owner) login is permitted. Tests that use
+# sg_connect (password auth) require ROG to be enabled. These helpers
+# detect, enable, and restore the setting so the test runner works even
+# when ROG is off by default.
+
+_OriginalGrantTypes=""
+_RogWasDisabled=false
+_GrantTypeSettingName="Allowed OAuth2 Grant Types"
+_GrantTypeSettingUrl="Settings/Allowed%20OAuth2%20Grant%20Types"
+
+# Query the current allowed grant types from the appliance.
+# Requires an active login session. Sets _OriginalGrantTypes.
+sg_get_grant_types()
+{
+    local settings
+    settings=$(sg_invoke -s core -m GET -U "Settings")
+    if [ -z "$settings" ]; then
+        >&2 echo "Warning: Failed to read appliance Settings"
+        return 1
+    fi
+    local setting_exists
+    setting_exists=$(echo "$settings" | jq -r ".[] | select(.Name==\"$_GrantTypeSettingName\") | .Name" 2>/dev/null)
+    if [ -z "$setting_exists" ]; then
+        >&2 echo "Warning: Could not find '$_GrantTypeSettingName' in Settings"
+        return 1
+    fi
+    _OriginalGrantTypes=$(echo "$settings" | jq -r ".[] | select(.Name==\"$_GrantTypeSettingName\") | .Value" 2>/dev/null)
+}
+
+# Ensure Resource Owner grant type is enabled. Must be called while
+# connected (login file exists). Saves original state for later restore.
+sg_ensure_rog_enabled()
+{
+    sg_get_grant_types || return 1
+
+    if echo "$_OriginalGrantTypes" | grep -qi "ResourceOwner"; then
+        echo "  Resource Owner grant is already enabled."
+        _RogWasDisabled=false
+        return 0
+    fi
+
+    echo "  Resource Owner grant is DISABLED -- enabling for tests..."
+    _RogWasDisabled=true
+
+    local NewValue
+    if [ -z "$_OriginalGrantTypes" ]; then
+        NewValue="ResourceOwner"
+    else
+        NewValue="$_OriginalGrantTypes, ResourceOwner"
+    fi
+    local Body
+    Body=$(jq -n --arg v "$NewValue" '{"Value": $v}')
+    local Result
+    Result=$(sg_invoke -s core -m PUT -U "$_GrantTypeSettingUrl" -b "$Body")
+    if [ -z "$Result" ]; then
+        >&2 echo "Error: Failed to enable Resource Owner grant type"
+        return 1
+    fi
+
+    echo "  Resource Owner grant enabled successfully."
+}
+
+# Restore the original grant type setting. Connects via PKCE (since ROG
+# may have just been disabled) and PUTs the original value back.
+sg_restore_rog()
+{
+    if [ "$_RogWasDisabled" != true ]; then
+        return 0
+    fi
+
+    echo ""
+    echo "Restoring original grant type setting..."
+
+    # Reconnect via PKCE for the restore (ROG-independent)
+    sg_disconnect
+    sg_connect_pkce
+
+    local Body
+    Body=$(jq -n --arg v "$_OriginalGrantTypes" '{"Value": $v}')
+    local Result
+    Result=$(sg_invoke -s core -m PUT -U "$_GrantTypeSettingUrl" -b "$Body")
+    if [ -z "$Result" ]; then
+        >&2 echo "Warning: Failed to restore original grant type setting"
+    else
+        echo "  Grant types restored to: $_OriginalGrantTypes"
+    fi
+
+    sg_disconnect
+}

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -112,6 +112,24 @@ fi
 
 echo "Found ${#SuiteFiles[@]} suite(s) to run."
 
+# --- Ensure Resource Owner Grant is enabled ---
+# Connect via PKCE first (works regardless of ROG state), check the
+# appliance grant-type setting, enable ROG if needed, then disconnect
+# so individual suites start with a clean session.
+echo ""
+echo "Connecting via PKCE to check Resource Owner grant type..."
+sg_connect_pkce
+if [ ! -f "$HOME/.safeguard_login" ]; then
+    >&2 echo "Error: PKCE connection failed. Cannot proceed."
+    exit 1
+fi
+
+sg_ensure_rog_enabled
+sg_disconnect
+
+# Guarantee ROG is restored on exit (even if tests fail or are interrupted)
+trap sg_restore_rog EXIT
+
 # Run each suite
 for suite_file in "${SuiteFiles[@]}"; do
     run_suite "$suite_file"

--- a/test/suites/suite-connect.sh
+++ b/test/suites/suite-connect.sh
@@ -56,6 +56,34 @@ suite_execute()
     # --- Test: Disconnect ---
     sg_disconnect
     sg_assert "disconnect-safeguard.sh removes login file" test ! -f "$LoginFile"
+
+    # --- Test: Connect to appliance via PKCE ---
+    sg_connect_pkce
+    sg_assert "connect-safeguard.sh -P creates login file" test -f "$LoginFile"
+
+    # --- Test: PKCE login file contains appliance address ---
+    local pkce_appliance=$(grep "^Appliance=" "$LoginFile" 2>/dev/null | cut -d= -f2)
+    sg_assert_equal "PKCE login file stores correct appliance" "$pkce_appliance" "$TestAppliance"
+
+    # --- Test: PKCE login file contains an access token ---
+    local pkce_token=$(grep "^AccessToken=" "$LoginFile" 2>/dev/null | cut -d= -f2)
+    sg_assert_not_null "PKCE login file contains access token" "$pkce_token"
+
+    # --- Test: PKCE login file records PKCE method ---
+    local pkce_flag=$(grep "^Pkce=" "$LoginFile" 2>/dev/null | cut -d= -f2)
+    sg_assert_equal "PKCE login file records Pkce=true" "$pkce_flag" "true"
+
+    # --- Test: PKCE token can make API calls ---
+    local pkce_me_result=$(sg_invoke -s core -m GET -U "Me")
+    sg_assert_not_null "PKCE: invoke-safeguard-method.sh GET Me returns data" "$pkce_me_result"
+
+    # --- Test: PKCE logged-in user matches ---
+    local pkce_user_name=$(echo "$pkce_me_result" | jq -r '.Name' 2>/dev/null | tr '[:upper:]' '[:lower:]')
+    sg_assert_equal "PKCE: Logged-in user matches test user" "$pkce_user_name" "$expected_user"
+
+    # --- Test: Disconnect after PKCE ---
+    sg_disconnect
+    sg_assert "disconnect after PKCE removes login file" test ! -f "$LoginFile"
 }
 
 suite_cleanup()


### PR DESCRIPTION
This allows connect-safeguard.sh to work even when the resource owners grant is turned off 