### PR TITLE
invoke-safeguard-method.sh failing in docker

### DIFF
--- a/src/invoke-safeguard-method.sh
+++ b/src/invoke-safeguard-method.sh
@@ -181,7 +181,7 @@ case $Method in
 -s
 $CABundleArg
 -X $Method
-"${ExtraHeader[@]}"
+${ExtraHeader[@]}
 -H "Accept: $Accept"
 -H "Authorization: Bearer $AccessToken"
 EOF
@@ -192,7 +192,7 @@ EOF
 -s
 $CABundleArg
 -X $Method
-"${ExtraHeader[@]}"
+${ExtraHeader[@]}
 -H "Accept: $Accept"
 -H "Content-type: $ContentType"
 -H "Authorization: Bearer $AccessToken"


### PR DESCRIPTION
Double quotes around ${ExtraHeader[@]} in the heredoc made the invoke-safeguard-method.sh script not work when run in the docker env. It threw the following error:
```
safeguard@425fd3a7cc28: ~ $ invoke-safeguard-method.sh -s core -U Me
curl: option -K: is unknown
curl: try 'curl --help' or 'curl --manual' for more information
```