### PR TITLE
chore: modernize pipeline for tag-based releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require review from SafeguardPasswords team for all changes
+* @OneIdentity/SafeguardPasswords
+

--- a/build.yml
+++ b/build.yml
@@ -4,20 +4,31 @@ variables:
 trigger:
   branches:
     include:
+      - main
       - master
       - release-*
+  tags:
+    include:
+      - 'v*'
   paths:
     exclude:
-      - README.md
+      - '**/*.md'
+      - LICENSE
+      - docs/
+      - .github/CODEOWNERS
 
 pr:
   branches:
     include:
+      - main
       - master
       - release-*
   paths:
     exclude:
-      - README.md
+      - '**/*.md'
+      - LICENSE
+      - docs/
+      - .github/CODEOWNERS
 
 jobs:
 # Job 1: PR Validation - runs only on pull requests
@@ -44,9 +55,9 @@ jobs:
         action: 'create'
         target: '$(Build.SourceVersion)'
         tagSource: 'userSpecifiedTag'
-        tag: 'release-$(VersionString)'
+        tag: '$(ReleaseTag)'
         title: '$(VersionString)'
-        isPreRelease: $(isPrerelease)
+        isPreRelease: ${{ not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}
         changeLogCompareToRelease: 'lastFullRelease'
         changeLogType: 'commitBased'
         assets: $(Build.ArtifactStagingDirectory)/*.zip

--- a/pipeline-templates/build-steps.yml
+++ b/pipeline-templates/build-steps.yml
@@ -4,7 +4,7 @@ steps:
     targetType: 'filePath'
     failOnStderr: true
     filePath: '$(System.DefaultWorkingDirectory)/versionnumber.sh'
-    arguments: $(version) $(Build.BuildId)
+    arguments: $(version) $(Build.BuildId) $(Build.SourceBranchName) $(isTagBuild)
   displayName: 'Setting build version'
 
 - task: Bash@3

--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,7 +1,9 @@
 variables:
   - name: version
     value: "8.2"
+  - name: isTagBuild
+    value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   - name: isPrerelease
-    value: ${{ true }}
+    value: ${{ not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')) }}
   - name: shouldPublishDocker
-    value: $[ eq( variables.isPrerelease, false ) ]
+    value: $[ startsWith(variables['Build.SourceBranch'], 'refs/tags/') ]

--- a/versionnumber.sh
+++ b/versionnumber.sh
@@ -1,18 +1,37 @@
 #!/bin/bash
-if [ "$#" -ne 2 ]; then
-    >&2 echo "This script requires 2 arguments -- verNum, buildId"
+if [ "$#" -lt 2 ]; then
+    >&2 echo "Usage: versionnumber.sh <verNum> <buildId> [tagName] [isTagBuild]"
     exit 1
 fi
 verNum=$1
 buildId=$2
+tagName=${3:-""}
+isTagBuild=${4:-"False"}
 
 echo "verNum = $verNum"
 echo "buildId = $buildId"
+echo "tagName = $tagName"
+echo "isTagBuild = $isTagBuild"
 
-buildNumber=$(expr $buildId - 103500) # shrink shared build number appropriately
-echo "buildNumber = ${buildNumber}"
+if [ "$isTagBuild" = "True" ] || [ "$isTagBuild" = "true" ]; then
+    # Validate tag format: must be v<major>.<minor>.<patch>
+    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+        >&2 echo "ERROR: Tag '$tagName' does not match expected format 'v<major>.<minor>.<patch>'. Aborting release build."
+        exit 1
+    fi
+    versionString="${tagName#v}"  # strip v prefix
+    releaseTag="$tagName"
+    echo "Tag build detected, using tag name as version"
+else
+    buildNumber=$(expr $buildId - 103500) # shrink shared build number appropriately
+    echo "buildNumber = ${buildNumber}"
+    versionString="$verNum.$buildNumber"
+    releaseTag="dev/v$versionString"
+    echo "Dev build"
+fi
 
-versionString="$verNum.$buildNumber"
 echo "VersionString = ${versionString}"
+echo "ReleaseTag = ${releaseTag}"
 
 echo "##vso[task.setvariable variable=VersionString;]$versionString"
+echo "##vso[task.setvariable variable=ReleaseTag;]$releaseTag"


### PR DESCRIPTION
## Changes

**Triggers:**
- Add `main` branch trigger (keep `master` and `release-*` for transition)
- Add `v*` tag trigger for tag-based releases
- Broaden path exclusions to `**/*.md`, `LICENSE`, `docs/`, `CODEOWNERS`

**Version script (`versionnumber.sh`):**
- Add tag-based mode: accepts tagName and isTagBuild arguments
- Validate tag format matches `v<major>.<minor>.<patch>` -- fail fast on bad tags
- Strip `v` prefix for version string
- Output new `ReleaseTag` variable (tag builds reuse trigger tag, dev builds use `dev/` prefix)

**Pipeline variables (`global-variables.yml`):**
- Add `isTagBuild` variable
- Derive `isPrerelease` from source branch (was hardcoded `true`)
- Derive `shouldPublishDocker` from source branch (was always `false` due to hardcoded isPrerelease)

**GitHubRelease:**
- Tag changed from `release-$(VersionString)` to `$(ReleaseTag)`
- `isPreRelease` computed from source branch instead of hardcoded variable

**Other:**
- Add CODEOWNERS requiring SafeguardPasswords team review

**Behavioral change:** Docker publishing will auto-enable for tag builds. It was permanently disabled because `isPrerelease` was hardcoded `true`. Verify DockerHub credentials are still valid before first tag release.