### PR TITLE
Fix tag validation regex: anchor end of pattern

### DIFF
--- a/pipeline-templates/versionnumber.sh
+++ b/pipeline-templates/versionnumber.sh
@@ -15,7 +15,7 @@ echo "isTagBuild = $isTagBuild"
 
 if [ "$isTagBuild" = "True" ] || [ "$isTagBuild" = "true" ]; then
     # Validate tag format: must be v<major>.<minor>.<patch>
-    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'; then
+    if ! echo "$tagName" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
         >&2 echo "ERROR: Tag '$tagName' does not match expected format 'v<major>.<minor>.<patch>'. Aborting release build."
         exit 1
     fi


### PR DESCRIPTION
The tag validation regex was missing the end-of-string anchor, so malformed tags like `v0.0.0-test` would pass validation and produce a release build. Adds `\$` to enforce exact `v<major>.<minor>.<patch>` format.