### PR TITLE
Skills harmonization: add architecture and build-and-release skills

### DIFF
--- a/.agents/skills/api-patterns/SKILL.md
+++ b/.agents/skills/api-patterns/SKILL.md
@@ -41,6 +41,24 @@ Resource Owner grant type to be enabled on the appliance.
 echo "MyPassword" | connect-safeguard.sh -a <appliance> -i local -u Admin -p
 ```
 
+### Non-interactive login (piped password)
+
+For scripting, pipe the password via stdin using the `-p` flag:
+
+```bash
+echo "Admin123" | src/connect-safeguard.sh -a 192.168.117.15 -i local -u Admin -p
+```
+
+The `-p` flag means "read password from stdin" (not "prompt for password").
+Without `-X`, this creates a login file (`~/.safeguard_login`) that subsequent
+commands pick up automatically — no need to pass credentials again.
+
+To create an explicit login file without the default path:
+
+```bash
+echo "Admin123" | src/connect-safeguard.sh -a 192.168.117.15 -i local -u Admin -p -O /tmp/my-login
+```
+
 ### 2. Certificate
 
 Client certificate + private key, provider set to `certificate`.
@@ -240,6 +258,20 @@ invoke-safeguard-method.sh -s core -m GET \
 invoke-safeguard-method.sh -s core -m GET \
     -U "Users?filter=Name%20eq%20'Admin'"
 ```
+
+### Query parameters
+
+Query parameters go IN the URL, not as separate flags:
+
+```bash
+# Correct — filter in the URL
+src/invoke-safeguard-method.sh -s core -m GET -U "Assets?filter=Name%20eq%20'MyAsset'"
+
+# Filter with URL encoding
+src/invoke-safeguard-method.sh -s core -m GET -U "Users?fields=Id,Name&filter=Disabled%20eq%20false"
+```
+
+There is no separate `-q` or `--query` flag for query parameters.
 
 ### URL Encoding Convention
 

--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -6,6 +6,28 @@ description: >-
   to add new commands safely.
 ---
 # safeguard-bash Architecture
+
+## Windows checkout / CRLF
+
+When this repository is checked out on Windows (or with `core.autocrlf=true`),
+all `.sh` files will have CRLF line endings. Bash cannot execute scripts with
+`\r\n` — you will see errors like `$'\r': command not found`.
+
+Before running any script from a Windows checkout in WSL or Linux:
+
+```bash
+# One-time fix for a working copy
+find . -name "*.sh" -exec sed -i 's/\r$//' {} \;
+
+# Or copy to a temp directory and fix there
+cp -r . /tmp/sg-bash && find /tmp/sg-bash -name "*.sh" -exec sed -i 's/\r$//' {} \;
+cd /tmp/sg-bash
+```
+
+The `.gitattributes` file should enforce LF for shell scripts in the
+repository, but the working copy on Windows may still have CRLF until the
+files are re-checked out with the correct settings.
+
 ## 1. Entry point / public API surface (script layout)
 The public surface is `src/`. Everything in `src/` except `src/utils/` is meant
 to be an executable command.

--- a/.agents/skills/architecture/SKILL.md
+++ b/.agents/skills/architecture/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: architecture
+description: >-
+  Use when understanding how safeguard-bash is organized, how scripts share
+  authentication and session state, how the utils library fits together, or how
+  to add new commands safely.
+---
+# safeguard-bash Architecture
+## 1. Entry point / public API surface (script layout)
+The public surface is `src/`. Everything in `src/` except `src/utils/` is meant
+to be an executable command.
+
+The same scripts are exposed in two delivery paths:
+- `install-local.sh` copies `src/*` into `$HOME/scripts`
+- `docker/Dockerfile` copies `src/` into `/scripts`
+
+The repo is therefore organized around shell commands first, with a small
+sourced helper layer underneath.
+
+### Script families
+The current 77 top-level scripts are easiest to navigate by prefix.
+
+| Family | Purpose | Examples |
+|---|---|---|
+| `connect-` / `disconnect-` | Session bootstrap and teardown | `connect-safeguard.sh`, `disconnect-safeguard.sh` |
+| `invoke-` / `show-` | Generic API helpers and discovery | `invoke-safeguard-method.sh`, `show-safeguard-method.sh` |
+| `get-` / `find-` | Read or search Safeguard resources | `get-platform.sh`, `find-event.sh`, `get-access-request.sh` |
+| `new-` / `edit-` / `remove-` / `set-` / `clear-` | CRUD and value updates | `new-user.sh`, `edit-event-subscription.sh`, `set-account-password.sh` |
+| `enable-` / `disable-` | Feature toggles | `enable-a2a-service.sh`, `disable-a2a-service.sh` |
+| `listen-for-` / `handle-` | SignalR listeners and handler orchestration | `listen-for-event.sh`, `handle-a2a-password-event.sh` |
+| `install-` / `uninstall-` | Certificate and license operations | `install-license.sh`, `uninstall-trusted-certificate.sh` |
+| `start-` / `close-` | Workflow-specific actions | `start-access-request-ssh-session.sh`, `close-access-request.sh` |
+
+### Domain groupings
+File names also cluster by Safeguard feature area:
+- **Session/core:** `connect-safeguard.sh`, `disconnect-safeguard.sh`,
+  `get-logged-in-user.sh`, `invoke-safeguard-method.sh`
+- **Users/assets/accounts:** `new-user.sh`, `remove-user.sh`, `new-asset.sh`,
+  `new-asset-account.sh`, `get-linked-account.sh`
+- **Access requests:** `new-access-request.sh`, `get-actionable-request.sh`,
+  `get-access-request-password.sh`, `edit-access-request.sh`
+- **A2A:** `new-a2a-registration.sh`, `get-a2a-password.sh`,
+  `set-a2a-privatekey.sh`, `new-a2a-access-request.sh`
+- **Events:** `get-event.sh`, `find-event.sh`, `new-event-subscription.sh`,
+  `listen-for-event.sh`, `handle-event.sh`
+- **Appliance/certificates:** `get-appliance-status.sh`,
+  `install-trusted-certificate.sh`, `get-support-bundle.sh`
+
+### Common script shape
+Most scripts follow this sequence:
+1. `print_usage()` first
+2. `ScriptDir` from `${BASH_SOURCE[0]}`
+3. initialize variables
+4. source helpers from `src/utils/`
+5. parse flags with `getopts`
+6. call `require_login_args` or `require_connect_args`
+7. make one API call or run one event loop
+
+Representative examples:
+- `new-user.sh` builds a body, POSTs to `Users`, then optionally does follow-up
+  PUTs for password and description
+- `new-event-subscription.sh` either accepts `-b` or builds the JSON payload
+  from `-D`, `-e`, `-T`, and `-U`
+- `get-appliance-status.sh` is an anonymous wrapper around
+  `invoke-safeguard-method.sh -n`
+
+## 2. Authentication strategy and flow (login scripts)
+`connect-safeguard.sh` is the standard login entry point for normal REST work.
+It supports three paths.
+
+### Password flow
+For non-certificate providers it POSTs to `/RSTS/oauth2/token` with:
+- `grant_type: password`
+- username/password
+- `scope: rsts:sts:primaryproviderid:<provider>`
+
+### Certificate flow
+For `-i certificate` it calls `/RSTS/oauth2/token` with client certificate and
+private key material, using `grant_type: client_credentials`.
+
+If curl cannot complete client TLS auth, the script falls back to
+`openssl s_client` and manually formulates the request.
+
+### PKCE flow
+With `-P`, the script simulates the browser-based PKCE flow:
+1. generate verifier/challenge and CSRF token
+2. initialize the rSTS login controller session
+3. submit primary credentials
+4. optionally complete secondary/MFA steps
+5. generate claims and extract the authorization code
+6. exchange the code for an rSTS token
+
+This path is blocked for the certificate provider.
+
+### Final token exchange
+All successful standard login paths converge here:
+1. obtain an rSTS access token
+2. POST it to `/service/core/v<version>/Token/LoginResponse`
+3. extract `UserToken`
+4. use that Safeguard bearer token for normal REST calls
+
+### Other auth entry points
+`invoke-safeguard-method.sh` can run with:
+- login-file auth (default)
+- explicit bearer token via `-t` or `-T`
+- anonymous auth via `-n`
+
+A2A scripts use a separate model:
+- client certificate + private key
+- `Authorization: A2A <apikey>`
+- `src/utils/a2a.sh` for the transport wrapper
+
+## 3. Connection lifecycle (session file, token management)
+Shared connection state lives in:
+
+```bash
+$HOME/.safeguard_login
+```
+
+`connect-safeguard.sh` creates the file with `umask 0077` and stores values such
+as `Appliance`, `CABundleArg`, `Provider`, `AccessToken`, `Cert`, `PKey`, and
+`Pkce=true` for PKCE sessions.
+
+### Resolution chain
+`src/utils/loginfile.sh` owns the lifecycle helpers:
+- `handle_ca_bundle_arg` resolves `--cacert` vs insecure `-k`
+- `use_login_file` reads the file or auto-runs `connect-safeguard.sh`
+- `require_login_args` fills in appliance/token state for normal scripts
+- `require_connect_args` prompts for provider, user, cert, key, and password
+
+Typical flow:
+1. initialize `Appliance`, `AccessToken`, `CABundle`
+2. source `utils/loginfile.sh`
+3. call `require_login_args`
+4. read from the login file if possible
+5. if still missing, run `connect-safeguard.sh -X` to mint a token
+
+### Teardown and refresh
+`disconnect-safeguard.sh` deletes the login file and calls
+`/service/core/v<version>/Token/Logout`.
+
+Short-lived CRUD commands assume the current token is good for the life of the
+process. Long-running handlers do more work:
+- `handle-event.sh` checks `LoginMessage`
+- it reads `X-TokenLifetimeRemaining`
+- it reconnects before expiry when it owns the credentials
+- raw bearer-token mode can continue only while that token stays valid
+
+## 4. Key abstractions and their relationships (utils library)
+`src/utils/` is the internal helper layer. It is sourced, not invoked as the
+main CLI surface.
+
+### `loginfile.sh`
+Responsibilities:
+- login-file location and parsing
+- prompting for missing auth inputs
+- provider discovery through `AuthenticationProviders`
+- CA bundle normalization
+- token bootstrap via `connect-safeguard.sh`
+
+Most authenticated scripts depend on this file directly.
+
+### `common.sh`
+This file is intentionally tiny. It only provides:
+- `backoff_wait`
+- `reset_backoff_wait`
+
+Those helpers are used by reconnecting event handlers such as `handle-event.sh`
+and the `handle-a2a-*` scripts.
+
+### `a2a.sh`
+`invoke_a2a_method` wraps:
+- certificate/key usage
+- A2A authorization headers
+- optional JSON bodies
+- curl first
+- `openssl s_client` fallback for TLS client-auth problems
+
+Representative consumers include `get-a2a-password.sh`,
+`get-a2a-privatekey.sh`, `set-a2a-password.sh`, and
+`new-a2a-access-request.sh`.
+
+### Cert/test utility scripts
+The other files in `src/utils/` are support tooling for samples and manual
+workflows:
+- `convert-pfx-to-pem.sh`
+- `add-pem-password.sh`
+- `remove-pem-password.sh`
+- `new-test-ca.sh`
+- `new-test-cert.sh`
+
+### Relationship model
+```text
+business script
+  -> loginfile.sh for auth/session state
+  -> invoke-safeguard-method.sh for normal REST
+  -> a2a.sh for mTLS + A2A REST
+  -> common.sh only if it owns a reconnect loop
+```
+
+## 5. Event system (if applicable)
+There are two related event stacks.
+
+### Standard Safeguard events
+Files involved:
+- `listen-for-event.sh`
+- `handle-event.sh`
+- `new/get/find/edit/remove-event-subscription.sh`
+- `get-event.sh`, `find-event.sh`, `get-event-name.sh`,
+  `get-event-category.sh`, `get-event-property.sh`
+
+`listen-for-event.sh` does the low-level SignalR work:
+1. call `/service/event/signalr/negotiate?negotiateVersion=1`
+2. extract `connectionToken`
+3. POST the JSON protocol handshake body
+4. open the streaming connection
+5. strip keepalive/blank lines and pretty-print payloads
+
+`handle-event.sh` is the resilient wrapper around that transport. It validates
+prereqs (`jq`, `coproc`, executable handler), refreshes tokens, runs the
+listener as a coprocess, filters events with `jq --unbuffered`, and invokes the
+handler with four stdin lines: appliance, access token, CA bundle path, and the
+event JSON.
+
+### A2A events
+Files involved:
+- `listen-for-a2a-event.sh`
+- `handle-a2a-password-event.sh`
+- `handle-a2a-privatekey-event.sh`
+- `handle-a2a-apikeysecret-event.sh`
+
+This stack listens to `/service/a2a/signalr` and authenticates with client
+certs + API key instead of a bearer token.
+
+The specialized `handle-a2a-*` scripts all follow the same pattern:
+1. fetch the current secret once at startup
+2. call the handler immediately with that initial value
+3. listen for matching A2A events
+4. refetch the secret after each event
+5. invoke the handler with the refreshed material
+
+That refetch-after-event design is deliberate: the event is only a trigger.
+
+## 6. Extension points (how to add new scripts)
+### Normal REST commands
+Use this path unless the feature is truly special-case:
+1. add `src/<verb>-<resource>.sh`
+2. source `utils/loginfile.sh`
+3. call `require_login_args`
+4. build the relative URL and JSON body
+5. delegate the HTTP call to `invoke-safeguard-method.sh`
+6. check `.Code` and return JSON consistently
+
+`new-user.sh` and `new-event-subscription.sh` are good modern examples.
+
+### Anonymous commands
+Follow `get-appliance-status.sh` and call `invoke-safeguard-method.sh -n`.
+
+### A2A commands
+Follow `get-a2a-password.sh` or `set-a2a-privatekey.sh`:
+- source `utils/a2a.sh`
+- gather appliance/cert/key/password/API key inputs
+- call `invoke_a2a_method`
+- only bypass it for streaming or handshake-only cases
+
+### Event consumers
+Keep the current split:
+- low-level connection logic in `listen-for-*.sh`
+- reconnection/filtering in `handle-*.sh`
+- business logic in the external handler script passed by `-S`
+
+### Tests and packaging
+When you add a public command:
+- add or extend an integration suite under `test/suites/`
+- use `test/framework.sh` helpers instead of ad hoc assertions
+- do not change the main Dockerfile unless packaging behavior itself changed;
+  it already copies the entire `src/`, `samples/`, and `test/` trees
+
+For turnkey demos, follow the sample pattern in `samples/certificate-login/` or
+`samples/event-handling/`: derive from the main image and copy only the extra
+script(s) and assets.

--- a/.agents/skills/build-and-release/SKILL.md
+++ b/.agents/skills/build-and-release/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: build-and-release
+description: >-
+  Use when working on safeguard-bash Azure Pipelines, Docker packaging, version
+  derivation, GitHub releases, or Docker Hub publishing.
+---
+
+# safeguard-bash Build and Release
+
+## Files involved
+
+| File | Role |
+|---|---|
+| `build.yml` | Main Azure DevOps pipeline entry point |
+| `pipeline-templates/global-variables.yml` | Shared version and publish variables |
+| `pipeline-templates/build-steps.yml` | Common build/package steps reused by both jobs |
+| `pipeline-templates/versionnumber.sh` | Computes `VersionString` and `ReleaseTag` |
+| `docker/Dockerfile` | Runtime image definition |
+| `docker/build.sh` | Local build helper for Docker image + zip artifact |
+| `docker/run.sh` | Local helper for running the image |
+
+## 1. Pipeline architecture (files, stages, triggers)
+
+The repo uses **Azure DevOps Pipelines**, not GitHub Actions.
+
+### Entry pipeline: `build.yml`
+
+`build.yml` imports `pipeline-templates/global-variables.yml` and defines both
+CI and PR behavior.
+
+#### Triggers
+
+Push builds run for:
+- `main`
+- `master`
+- `release-*`
+- tags matching `v*`
+
+PR validation runs for:
+- `main`
+- `master`
+- `release-*`
+
+Both trigger blocks exclude documentation-only changes:
+- `**/*.md`
+- `LICENSE`
+- `docs/`
+- `.github/CODEOWNERS`
+
+### Jobs
+
+| Job | Condition | What it does |
+|---|---|---|
+| `PRValidation` | `Build.Reason == PullRequest` | Runs the shared build/package steps only |
+| `BuildAndPublish` | `Build.Reason != PullRequest` | Runs the shared build/package steps, creates a GitHub release, and optionally pushes Docker images |
+
+Both jobs run on `ubuntu-latest`.
+
+### Shared build steps: `pipeline-templates/build-steps.yml`
+
+The shared template performs the packaging work in this order:
+1. run `pipeline-templates/versionnumber.sh`
+2. dump environment variables for diagnostics
+3. run `docker/build.sh $(VersionString) $(Build.SourceVersion)`
+4. tag `oneidentity/safeguard-bash:latest`
+5. copy the generated zip file to the artifact staging directory
+6. publish the Azure Pipeline artifact
+
+### Docker packaging path
+
+`docker/build.sh` is the real build implementation used by the pipeline. It:
+- builds `oneidentity/safeguard-bash:<version>-alpine`
+- tags `oneidentity/safeguard-bash:latest`
+- creates `safeguard-bash-<version>.zip`
+- packages `install-local.sh`, `src/`, `samples/`, and `test/`
+
+`docker/Dockerfile` builds the runtime image from `alpine`, installs the shell
+and network tooling, copies repository content into `/scripts`, `/samples`, and
+`/test`, and defaults the shell to launch with `connect-safeguard.sh` available.
+
+## 2. Version strategy (how version numbers are derived)
+
+### Base version
+
+`pipeline-templates/global-variables.yml` currently defines:
+
+```yaml
+version: "8.2.0"
+```
+
+That is the base version used by the release helper.
+
+### Tag builds
+
+A tag build is detected when `Build.SourceBranch` starts with `refs/tags/`.
+
+`versionnumber.sh` then enforces this format:
+
+```text
+v<major>.<minor>.<patch>
+```
+
+If the tag is valid:
+- `VersionString` becomes the tag without the leading `v`
+- `ReleaseTag` stays the original tag, for example `v8.2.0`
+
+If the tag is not semver-shaped, the script exits non-zero and the release build
+fails.
+
+### Non-tag builds
+
+For non-tag builds, `versionnumber.sh`:
+- keeps `VersionString` equal to the base version from `global-variables.yml`
+- derives a smaller prerelease number with `expr $buildId - 103500`
+- emits `ReleaseTag=dev/v<base-version>-pre<buildNumber>`
+
+Example:
+- base version: `8.2.0`
+- build id: `103900`
+- release tag: `dev/v8.2.0-pre400`
+
+### Publish gating
+
+`global-variables.yml` also sets:
+- `isTagBuild`
+- `isPrerelease`
+- `shouldPublishDocker`
+
+`shouldPublishDocker` is only true for tag builds, so Docker Hub publishing is
+release-only even though the image is built on every pipeline run.
+
+## 3. Build commands (local reproduction)
+
+### Reproduce the packaging step locally
+
+From the repo root:
+
+```bash
+./docker/build.sh <version> <commit-sha>
+```
+
+Example:
+
+```bash
+./docker/build.sh 8.2.0 abcdef1234567890
+```
+
+This produces:
+- `oneidentity/safeguard-bash:8.2.0-alpine`
+- `oneidentity/safeguard-bash:latest`
+- `safeguard-bash-8.2.0.zip`
+
+### Preview version derivation locally
+
+You can run the same helper the pipeline uses:
+
+```bash
+./pipeline-templates/versionnumber.sh 8.2.0 103900 main false
+./pipeline-templates/versionnumber.sh 8.2.0 103900 v8.2.0 true
+```
+
+The script writes Azure DevOps variable commands to stdout, so use it mainly to
+verify the derived `VersionString` and `ReleaseTag` behavior.
+
+### Run the built image locally
+
+```bash
+./docker/run.sh
+./docker/run.sh -c /bin/bash
+```
+
+Use `-v <hostdir>` with `docker/run.sh` if you need to mount certs or keys into
+`/volume`.
+
+## 4. Publishing targets (Docker Hub, GitHub Releases, etc.)
+
+### Azure Pipeline artifacts
+
+Every pipeline run publishes a build artifact named:
+
+```text
+safeguard-bash-$(VersionString)
+```
+
+The artifact contains the generated zip file.
+
+### GitHub Releases
+
+The `BuildAndPublish` job always creates a GitHub release in:
+
+```text
+OneIdentity/safeguard-bash
+```
+
+Pipeline behavior:
+- target commit: `$(Build.SourceVersion)`
+- tag source: `userSpecifiedTag`
+- tag/title: `$(ReleaseTag)`
+- changelog: commit-based, compared to the last full release
+- asset upload: the generated zip file
+- prerelease flag: true for non-tag builds, false for tag builds
+
+So merges to `main`, `master`, or `release-*` produce prerelease-style GitHub
+releases even when Docker images are not pushed.
+
+### Docker Hub
+
+The pipeline pushes Docker images only when `shouldPublishDocker == true`, which
+means **tag builds only**.
+
+Published tags:
+- `oneidentity/safeguard-bash:$(VersionString)-alpine`
+- `oneidentity/safeguard-bash:latest`
+
+The login step uses a fixed Docker Hub username:
+
+```text
+danpetersonoi
+```
+
+and reads the secret token from Azure Key Vault.
+
+## 5. Service connections / secrets required
+
+The release path depends on Azure DevOps resources that are external to the
+repo.
+
+### Service connections
+
+| Resource | Where used | Purpose |
+|---|---|---|
+| `PangaeaBuild-GitHub` | `GitHubRelease@1` | Create GitHub releases in `OneIdentity/safeguard-bash` |
+| `SafeguardOpenSource` | `AzureKeyVault@2` | Authorize access to the Azure Key Vault holding publish secrets |
+
+### Key Vault
+
+The pipeline reads secrets from:
+
+```text
+SafeguardBuildSecrets
+```
+
+Requested secrets:
+- `DockerHubAccessToken`
+- `DockerHubPassword`
+
+Only `DockerHubAccessToken` is actually consumed by the current Docker login
+command. `DockerHubPassword` is still requested, so treat it as part of the
+expected release environment unless the pipeline is cleaned up.
+
+### Runtime/tooling assumptions
+
+The pipeline also assumes:
+- Docker is available on `ubuntu-latest`
+- bash can execute `versionnumber.sh` and `docker/build.sh`
+- zip creation works on the hosted agent
+
+If a release change touches versioning, Docker tags, GitHub release behavior, or
+publish secrets, inspect **all** of `build.yml`, `pipeline-templates/`, and
+`docker/build.sh` together before changing anything.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,189 +1,105 @@
 # AGENTS.md — AI Agent Instructions for safeguard-bash
 
-## Project Overview
+safeguard-bash is a Bash + cURL SDK for **One Identity Safeguard for
+Privileged Passwords (SPP)**. Public commands live in `src/`; `install-local.sh`
+copies them to `$HOME/scripts`, and `docker/Dockerfile` copies them to
+`/scripts`.
 
-safeguard-bash is a Bash + cURL scripting SDK for the **One Identity Safeguard
-for Privileged Passwords (SPP)** REST API. Each script in `src/` is a
-self-contained CLI command that wraps one or more Safeguard API operations.
-
-Scripts run standalone on any system with bash, curl, and jq, or inside an
-Alpine-based Docker container.
-
-### Reference: safeguard-ps (PowerShell SDK)
-
-The **[OneIdentity/safeguard-ps](https://github.com/OneIdentity/safeguard-ps)**
-repository is the PowerShell equivalent — significantly more mature and
-feature-rich. Consult it for missing functionality, API usage patterns, and
-testing strategies.
-
----
+Reference repo: **[OneIdentity/safeguard-ps](https://github.com/OneIdentity/safeguard-ps)**
+for PowerShell equivalents, broader API coverage, and testing ideas.
 
 ## Project Structure
 
 ```
 safeguard-bash/
-├── src/                    # CLI scripts (the SDK) — 77 scripts
-│   └── utils/              # Shared libraries (loginfile.sh, a2a.sh, common.sh)
-├── test/                   # Integration test framework
-│   ├── run-tests.sh        # Test runner entry point
-│   ├── framework.sh        # Test framework library
-│   └── suites/             # Test suite scripts (suite-*.sh)
-├── samples/                # Example integrations
-├── pipeline-templates/     # Azure DevOps CI/CD YAML + versionnumber.sh
-├── docker/                 # Docker packaging
-│   ├── Dockerfile          # Alpine container definition
-│   ├── build.sh            # Build Docker image + create zip artifact
-│   ├── run.sh              # Run Docker container locally
-│   └── .bashrc             # Container shell config
-├── install-local.sh        # Install scripts to $HOME/scripts
+├── src/                # Public CLI commands
+│   └── utils/          # Shared sourced helpers
+├── test/               # Integration runner, framework, suites
+├── samples/            # Example integrations and demo images
+├── pipeline-templates/ # Shared Azure Pipeline steps/version helper
+├── docker/             # Main image + local build/run helpers
+└── install-local.sh    # Copies src/ into $HOME/scripts
 ```
 
----
-
-## Setup and Development Workflow
-
-There is no build step. Scripts are pure bash.
+## Setup and Build
 
 ```bash
-./install-local.sh          # Install scripts to $HOME/scripts
-. ~/.bash_profile           # Pick up PATH change
+./install-local.sh
+. ~/.bash_profile
+./docker/build.sh <version> <commit-sha>
+./docker/run.sh
 ```
 
-After editing scripts in `src/`, re-run `./install-local.sh` to copy changes.
-There is no linter or formatter for this project.
+Re-run `./install-local.sh` after editing `src/` so `$HOME/scripts` stays in
+sync.
 
----
+## Linting
 
-## Script Conventions
+N/A — no linter configured.
 
-### Script Template
-
-Every script in `src/` follows this structure:
+## Testing
 
 ```bash
-#!/bin/bash
-
-print_usage()
-{
-    cat <<EOF
-USAGE: script-name.sh [-h]
-       script-name.sh [-a appliance] [-B cabundle] ...
-
-  -h  Show help and exit
-  -a  Network address of the appliance
-  ...
-
-EOF
-    exit 0
-}
-
-ScriptDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-Appliance=
-CABundle=
-CABundleArg=
-Version=4
-
-. "$ScriptDir/utils/loginfile.sh"
-
-while getopts ":a:B:v:h" opt; do
-    case $opt in
-    a) Appliance=$OPTARG ;;
-    B) CABundle=$OPTARG ;;
-    v) Version=$OPTARG ;;
-    h) print_usage ;;
-    esac
-done
+./test/run-tests.sh -a <appliance> -u <user> -p <password>
+./test/run-tests.sh -a <appliance> -u <user> -p <password> -s connect
 ```
 
-**Key rules:**
-- `print_usage()` is always first, uses a heredoc, exits 0
-- `ScriptDir` via `${BASH_SOURCE[0]}` (not `$0`) — critical for sourcing
-- All variables initialized before the `getopts` loop
-- Utilities sourced with `. "$ScriptDir/utils/loginfile.sh"`
-- Leading `:` in getopts string suppresses built-in error messages
+- Tests require a live Safeguard appliance.
+- `test/framework.sh` provides the shared `sg_*` helpers.
+- `test/suites/suite-*.sh` groups tests by feature area.
 
-### Common Option Flags
+## Code Conventions
 
-| Flag | Meaning |
-|------|---------|
-| `-h` | Show help |
-| `-a` | Appliance network address |
-| `-B` | CA bundle for SSL validation |
-| `-v` | API version (default: 4) |
-| `-i` | Identity provider |
-| `-u` | Username |
-| `-c` | Client certificate file |
-| `-k` | Client private key file |
-| `-t` | Access token |
-| `-p` | Read password from stdin |
-| `-P` | Use PKCE authentication |
+- Keep `print_usage()` first and implemented with a heredoc.
+- Resolve `ScriptDir` from `${BASH_SOURCE[0]}` before sourcing helpers.
+- Initialize variables before `getopts`.
+- Use `src/utils/loginfile.sh` for shared login-file handling.
+- Use `invoke-safeguard-method.sh` for normal REST calls and `src/utils/a2a.sh`
+  for A2A mTLS calls.
+- Keep long-running reconnect logic in the `listen-for-*` / `handle-*` pattern.
 
-### Error Handling
-
-```bash
->&2 echo "Error message"                      # Errors to stderr
-
-if [ $? -ne 0 ]; then exit 1; fi             # Check curl exit codes
-
-Error=$(echo $Result | jq .Code 2> /dev/null) # Detect JSON API errors
-if [ -z "$Error" -o "$Error" = "null" ]; then
-    echo $Result
-else
-    echo $Result | jq . ; exit 1
-fi
-```
-
-### Login File Pattern
-
-Scripts share auth state via `$HOME/.safeguard_login` (key=value, `umask 0077`).
-The `require_login_args` function in `utils/loginfile.sh` handles the full
-chain: login file → prompt → connect. Call `require_login_args` after getopts.
-
-**Lifecycle:** `connect-safeguard.sh` creates → other scripts read via
-`require_login_args` → `disconnect-safeguard.sh` invalidates and removes.
-
-### Sourcing Shared Utilities
-
-```bash
-. "$ScriptDir/utils/loginfile.sh"
-. "$ScriptDir/utils/common.sh"
-. "$ScriptDir/utils/a2a.sh"
-```
-
----
-
-## Dependencies
-
-`bash`, `curl`, `jq` (strongly recommended), `openssl`, `sed`, `grep`.
-
----
+For deeper structure and extension guidance, read the `architecture` and
+`new-script-guide` skills.
 
 ## CI/CD
 
-Azure DevOps Pipelines (`build.yml` + `pipeline-templates/`):
-- **PR validation**: builds Docker image
-- **Merge to master/release-***: GitHub release + Docker Hub push
-
----
+See `.agents/skills/build-and-release/SKILL.md` for Azure Pipelines, Docker
+packaging, version derivation, publishing targets, and required secrets.
 
 ## Security
 
-- Never commit secrets, tokens, or credentials
-- The login file contains access tokens — don't log or serialize it
-- Test credentials are passed only as CLI arguments, never hardcoded
-- `-k` (disable SSL verification) is the default — don't recommend for production
+- Never commit secrets, tokens, certificates, or private keys.
+- Treat `$HOME/.safeguard_login` as sensitive because it stores access tokens.
+- `-k` / insecure TLS is acceptable for local testing, not for production
+  guidance.
+- Keep sample-only credentials and demo shortcuts out of product workflows.
 
----
+## Versioning
+
+- Scripts default to Safeguard API **v4** unless callers override `-v`.
+- Release versioning is driven by `pipeline-templates/global-variables.yml` and
+  `pipeline-templates/versionnumber.sh`.
+- Release tags must be `v<major>.<minor>.<patch>`; non-tag builds use
+  `dev/v<base-version>-pre<buildNumber>`.
 
 ## On-Demand Skills
 
-The following skills contain reference material loaded only when relevant.
-Read the `SKILL.md` when your current task matches the trigger.
-
 | Skill | When to read | File |
-|-------|-------------|------|
-| Testing Guide | Running tests, writing tests, test failures, test setup | `.agents/skills/testing-guide/SKILL.md` |
-| API Patterns | Making API calls, SCIM filters, creating users/assets, API gotchas | `.agents/skills/api-patterns/SKILL.md` |
-| A2A Workflow | A2A scripts, cert auth, credential retrieval, brokering, events | `.agents/skills/a2a-workflow/SKILL.md` |
-| New Script Guide | Creating a new script in src/, adding commands | `.agents/skills/new-script-guide/SKILL.md` |
+|-------|--------------|------|
+| Architecture | Repo layout, auth/session flow, utils, events | `.agents/skills/architecture/SKILL.md` |
+| Build & Release | Pipelines, Docker packaging, releases, publish secrets | `.agents/skills/build-and-release/SKILL.md` |
+| Testing Guide | Running or extending integration tests | `.agents/skills/testing-guide/SKILL.md` |
+| API Patterns | REST usage, filters, payload patterns, API gotchas | `.agents/skills/api-patterns/SKILL.md` |
+| A2A Workflow | A2A auth, credential retrieval, brokering, A2A events | `.agents/skills/a2a-workflow/SKILL.md` |
+| New Script Guide | Adding or extending commands in `src/` | `.agents/skills/new-script-guide/SKILL.md` |
+
+## Dependencies
+
+`bash`, `curl`, `jq` (strongly recommended), `openssl`, `sed`, `grep`, and
+`docker` for container workflows.
+
+## Keeping this file current
+
+Update this file when repo layout, setup/test commands, CI/CD entry points, or
+skill routing change. Keep only broad always-on guidance here; move detailed
+reference/workflow content into `.agents/skills/`.


### PR DESCRIPTION
Implements the skills harmonization plan:

- Created `architecture` skill (script patterns, utils library, login flow, Docker)
- Created `build-and-release` skill (extracted CI/CD from AGENTS.md)
- Updated AGENTS.md to standard template (linting N/A, versioning, skill routing)

Part of cross-repo effort to standardize agent skills across all Safeguard SDK repositories.