### PR TITLE
Add device code login integration test suite

### DIFF
--- a/pipeline-templates/global-variables.yml
+++ b/pipeline-templates/global-variables.yml
@@ -1,6 +1,6 @@
 variables:
   - name: version
-    value: "8.3.1"
+    value: "8.3.2"
   - name: isTagBuild
     value: ${{ startsWith(variables['Build.SourceBranch'], 'refs/tags/') }}
   - name: isPrerelease

--- a/test/framework.sh
+++ b/test/framework.sh
@@ -317,14 +317,17 @@ sg_invoke()
     "$ScriptDir/../src/invoke-safeguard-method.sh" "$@" 2>/dev/null
 }
 
-# --- Resource Owner Grant (ROG) Management ---
-# The Safeguard "Allowed OAuth2 Grant Types" setting controls whether
-# password-based (Resource Owner) login is permitted. Tests that use
-# sg_connect (password auth) require ROG to be enabled. These helpers
-# detect, enable, and restore the setting so the test runner works even
-# when ROG is off by default.
+# --- OAuth2 Grant Type Management ---
+# The Safeguard "Allowed OAuth2 Grant Types" setting is a comma-separated
+# list controlling which login flows are permitted (e.g. ResourceOwner,
+# AuthorizationCode, DeviceCode). Tests that exercise a specific flow need
+# to read, mutate, and restore this setting. These generic helpers operate
+# on any grant type; the Resource Owner (ROG) wrappers below are kept for
+# backward compatibility with the test runner.
 
 _OriginalGrantTypes=""
+_SavedGrantTypes=""
+_GrantTypesSaved=false
 _RogWasDisabled=false
 _GrantTypeSettingName="Allowed OAuth2 Grant Types"
 _GrantTypeSettingUrl="Settings/Allowed%20OAuth2%20Grant%20Types"
@@ -348,11 +351,119 @@ sg_get_grant_types()
     _OriginalGrantTypes=$(echo "$settings" | jq -r ".[] | select(.Name==\"$_GrantTypeSettingName\") | .Value" 2>/dev/null)
 }
 
+# PUT a raw grant-type value string back to the appliance.
+# Requires an active login session. Usage: sg_put_grant_types "<value>"
+sg_put_grant_types()
+{
+    local value="$1"
+    local Body Result
+    Body=$(jq -n --arg v "$value" '{"Value": $v}')
+    Result=$(sg_invoke -s core -m PUT -U "$_GrantTypeSettingUrl" -b "$Body")
+    if [ -z "$Result" ]; then
+        return 1
+    fi
+}
+
+# Enable or disable a single grant type while preserving the others.
+# Requires an active login session.
+# Usage: sg_set_grant_type_enabled "DeviceCode" true|false
+sg_set_grant_type_enabled()
+{
+    local grant_type="$1"
+    local desired="$2"
+
+    sg_get_grant_types || return 1
+
+    local new_value=""
+    local found=false
+    local token trimmed
+    local old_ifs="$IFS"
+    IFS=','
+    for token in $_OriginalGrantTypes; do
+        trimmed=$(echo "$token" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+        [ -z "$trimmed" ] && continue
+        if echo "$trimmed" | grep -qi "^${grant_type}$"; then
+            found=true
+            if [ "$desired" = true ]; then
+                if [ -z "$new_value" ]; then new_value="$trimmed"; else new_value="$new_value, $trimmed"; fi
+            fi
+        else
+            if [ -z "$new_value" ]; then new_value="$trimmed"; else new_value="$new_value, $trimmed"; fi
+        fi
+    done
+    IFS="$old_ifs"
+
+    if [ "$desired" = true ] && [ "$found" != true ]; then
+        if [ -z "$new_value" ]; then new_value="$grant_type"; else new_value="$new_value, $grant_type"; fi
+    fi
+
+    # Nothing to change if the type is already in the desired state.
+    if [ "$desired" = true ] && [ "$found" = true ]; then
+        return 0
+    fi
+    if [ "$desired" != true ] && [ "$found" != true ]; then
+        return 0
+    fi
+
+    if ! sg_put_grant_types "$new_value"; then
+        >&2 echo "Error: Failed to set grant type '$grant_type' enabled=$desired"
+        return 1
+    fi
+}
+
+# Ensure a grant type is enabled. Must be called while connected.
+# Usage: sg_ensure_grant_type_enabled "DeviceCode"
+sg_ensure_grant_type_enabled()
+{
+    local grant_type="$1"
+    sg_get_grant_types || return 1
+    if echo "$_OriginalGrantTypes" | grep -qi "$grant_type"; then
+        return 0
+    fi
+    sg_set_grant_type_enabled "$grant_type" true
+}
+
+# Save the current grant-type setting once for an exact restore later.
+# Requires an active login session.
+sg_save_grant_types()
+{
+    sg_get_grant_types || return 1
+    if [ "$_GrantTypesSaved" != true ]; then
+        _SavedGrantTypes="$_OriginalGrantTypes"
+        _GrantTypesSaved=true
+    fi
+}
+
+# Restore the exact grant-type string captured by sg_save_grant_types.
+# Reconnects via PKCE (grant-type-independent) before writing.
+sg_restore_grant_types()
+{
+    if [ "$_GrantTypesSaved" != true ]; then
+        return 0
+    fi
+
+    sg_disconnect
+    sg_connect_pkce
+
+    if sg_put_grant_types "$_SavedGrantTypes"; then
+        echo "  Grant types restored to: $_SavedGrantTypes"
+    else
+        >&2 echo "Warning: Failed to restore original grant type setting"
+    fi
+
+    sg_disconnect
+}
+
+# --- Resource Owner Grant (ROG) compatibility wrappers ---
+# The test runner relies on these names. They delegate to the generic
+# grant-type helpers above so password (Resource Owner) login works even
+# when ROG is off by default.
+
 # Ensure Resource Owner grant type is enabled. Must be called while
 # connected (login file exists). Saves original state for later restore.
 sg_ensure_rog_enabled()
 {
-    sg_get_grant_types || return 1
+    sg_save_grant_types || return 1
 
     if echo "$_OriginalGrantTypes" | grep -qi "ResourceOwner"; then
         echo "  Resource Owner grant is already enabled."
@@ -363,17 +474,7 @@ sg_ensure_rog_enabled()
     echo "  Resource Owner grant is DISABLED -- enabling for tests..."
     _RogWasDisabled=true
 
-    local NewValue
-    if [ -z "$_OriginalGrantTypes" ]; then
-        NewValue="ResourceOwner"
-    else
-        NewValue="$_OriginalGrantTypes, ResourceOwner"
-    fi
-    local Body
-    Body=$(jq -n --arg v "$NewValue" '{"Value": $v}')
-    local Result
-    Result=$(sg_invoke -s core -m PUT -U "$_GrantTypeSettingUrl" -b "$Body")
-    if [ -z "$Result" ]; then
+    if ! sg_set_grant_type_enabled "ResourceOwner" true; then
         >&2 echo "Error: Failed to enable Resource Owner grant type"
         return 1
     fi
@@ -381,8 +482,7 @@ sg_ensure_rog_enabled()
     echo "  Resource Owner grant enabled successfully."
 }
 
-# Restore the original grant type setting. Connects via PKCE (since ROG
-# may have just been disabled) and PUTs the original value back.
+# Restore the original grant type setting if ROG was enabled for tests.
 sg_restore_rog()
 {
     if [ "$_RogWasDisabled" != true ]; then
@@ -391,20 +491,5 @@ sg_restore_rog()
 
     echo ""
     echo "Restoring original grant type setting..."
-
-    # Reconnect via PKCE for the restore (ROG-independent)
-    sg_disconnect
-    sg_connect_pkce
-
-    local Body
-    Body=$(jq -n --arg v "$_OriginalGrantTypes" '{"Value": $v}')
-    local Result
-    Result=$(sg_invoke -s core -m PUT -U "$_GrantTypeSettingUrl" -b "$Body")
-    if [ -z "$Result" ]; then
-        >&2 echo "Warning: Failed to restore original grant type setting"
-    else
-        echo "  Grant types restored to: $_OriginalGrantTypes"
-    fi
-
-    sg_disconnect
+    sg_restore_grant_types
 }

--- a/test/suites/suite-device-code.sh
+++ b/test/suites/suite-device-code.sh
@@ -40,6 +40,13 @@ suite_setup()
     fi
     SuiteData[OrigGrantTypes]="$_OriginalGrantTypes"
 
+    # The runner's EXIT trap only restores Resource Owner grant; suite_cleanup is
+    # what restores the full captured set, but it does not run if the operator
+    # interrupts (Ctrl+C / SIGTERM) mid-execute -- which would leave DeviceCode
+    # disabled after Test 2. Arm a signal trap so the restore still runs; it is
+    # disarmed at the top of suite_cleanup for the normal path.
+    trap 'suite_cleanup; exit 130' INT TERM
+
     # Ensure DeviceCode is enabled for the baseline/E2E cases.
     sg_ensure_grant_type_enabled "DeviceCode"
 
@@ -182,6 +189,10 @@ suite_execute()
 suite_cleanup()
 {
     local LoginFile="$HOME/.safeguard_login"
+
+    # Disarm the interrupt trap armed in setup so it cannot re-enter this cleanup
+    # or leak into a subsequent suite.
+    trap - INT TERM
 
     # Always restore the EXACT original grant-type value captured at setup,
     # even if the test body failed. Reconnect via PKCE (grant-type-independent)

--- a/test/suites/suite-device-code.sh
+++ b/test/suites/suite-device-code.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Suite: Device Code Login
+# Tests connect-safeguard.sh -D (OAuth 2.0 Device Authorization Grant):
+#   - disabled-grant negative case (DeviceCode removed from allowed grants)
+#   - enabled baseline (verification URL + user code surfaced on stderr)
+#   - optional opt-in scripted no-human approval E2E (LOCAL/no-MFA only)
+#
+# The suite mutates the appliance "Allowed OAuth2 Grant Types" setting, so it
+# saves the exact original value at setup and restores it in cleanup, even when
+# the test body fails. $HOME/.safeguard_login is treated as sensitive: tokens
+# are never echoed in assertion output.
+
+suite_name()
+{
+    echo "Device Code Login"
+}
+
+suite_setup()
+{
+    local LoginFile="$HOME/.safeguard_login"
+
+    # Start from a clean, disconnected state.
+    sg_disconnect
+    rm -f "$LoginFile" 2>/dev/null
+
+    # Connect via PKCE (works regardless of grant-type configuration) so we
+    # can read and mutate the grant-type setting.
+    sg_connect_pkce
+    if [ ! -f "$LoginFile" ]; then
+        >&2 echo "  Device Code setup: PKCE connect failed; cannot manage grant types."
+        return 1
+    fi
+
+    # Save the EXACT current grant-type value for restore in cleanup. This is
+    # captured per-suite (independent of the runner's ROG save) so cleanup
+    # restores the state as it was on suite entry.
+    if ! sg_get_grant_types; then
+        >&2 echo "  Device Code setup: could not read Allowed OAuth2 Grant Types."
+        return 1
+    fi
+    SuiteData[OrigGrantTypes]="$_OriginalGrantTypes"
+
+    # Ensure DeviceCode is enabled for the baseline/E2E cases.
+    sg_ensure_grant_type_enabled "DeviceCode"
+
+    return 0
+}
+
+suite_execute()
+{
+    local LoginFile="$HOME/.safeguard_login"
+
+    # ----------------------------------------------------------------------
+    # Test 2: Disabled-grant error (reactive)
+    # ----------------------------------------------------------------------
+    # Remove DeviceCode from the allowed grant types, disconnect, then attempt
+    # a device-code login and assert it fails with a CLI-visible disabled-grant
+    # message. The DeviceLogin error body is HTML, not JSON, so detection stays
+    # reactive against the CLI-surfaced text and tolerates summarized wording.
+    sg_set_grant_type_enabled "DeviceCode" false
+    sg_disconnect
+    rm -f "$LoginFile" 2>/dev/null
+
+    local disabled_output disabled_exit
+    disabled_output=$("$ScriptDir/../src/connect-safeguard.sh" \
+        -a "$TestAppliance" -i local -v "$TestVersion" -D 2>&1)
+    disabled_exit=$?
+
+    sg_assert "Disabled DeviceCode: connect exits non-zero" \
+        test "$disabled_exit" -ne 0
+    sg_assert "Disabled DeviceCode: no login file is created" \
+        test ! -f "$LoginFile"
+
+    # The output must identify the device authorization request context.
+    local disabled_has_context=false
+    if echo "$disabled_output" | grep -qi "device"; then
+        disabled_has_context=true
+    fi
+    sg_assert_equal "Disabled DeviceCode: output references device-login context" \
+        "$disabled_has_context" "true"
+
+    # The output must indicate a grant/not-allowed/disabled condition. Prefer
+    # the exact appliance marker when present; otherwise accept the summarized
+    # "grant type ... not enabled/allowed/disabled" wording the CLI surfaces.
+    local disabled_has_marker=false
+    if echo "$disabled_output" | grep -qi "device code grant type is not allowed"; then
+        disabled_has_marker=true
+    elif echo "$disabled_output" | grep -qiE "grant type.*(not.*(allowed|enabled)|disabled)"; then
+        disabled_has_marker=true
+    elif echo "$disabled_output" | grep -qiE "not allowed|not enabled|disabled"; then
+        disabled_has_marker=true
+    fi
+    sg_assert_equal "Disabled DeviceCode: output indicates grant not allowed/disabled" \
+        "$disabled_has_marker" "true"
+
+    # ----------------------------------------------------------------------
+    # Test 3: Enabled baseline -- request succeeds and code is surfaced
+    # ----------------------------------------------------------------------
+    # Re-enable DeviceCode, then start a device-code login capturing stderr.
+    # Use capture-then-terminate so the baseline does not poll until the code
+    # expires; token/login-file assertions are not applicable without approval.
+    sg_connect_pkce
+    sg_ensure_grant_type_enabled "DeviceCode"
+    sg_disconnect
+    rm -f "$LoginFile" 2>/dev/null
+
+    local errfile="$ScriptDir/.device-code-baseline.$$.stderr"
+    rm -f "$errfile" 2>/dev/null
+
+    "$ScriptDir/../src/connect-safeguard.sh" \
+        -a "$TestAppliance" -i local -v "$TestVersion" -D >/dev/null 2>"$errfile" &
+    local dc_pid=$!
+
+    # Wait until the user-code instructions appear, the process exits, or we
+    # hit a short cap -- whichever comes first.
+    local waited=0
+    while [ $waited -lt 30 ]; do
+        if grep -q "and enter the code:" "$errfile" 2>/dev/null; then
+            break
+        fi
+        if ! kill -0 "$dc_pid" 2>/dev/null; then
+            break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    # Terminate the polling process so the baseline never hangs to expiry.
+    kill "$dc_pid" 2>/dev/null
+    wait "$dc_pid" 2>/dev/null
+
+    local baseline_output
+    baseline_output=$(cat "$errfile" 2>/dev/null)
+    rm -f "$errfile" 2>/dev/null
+
+    sg_assert_contains "Baseline: stderr prompts to open a web browser" \
+        "$baseline_output" "To sign in, use a web browser to open the page:"
+    sg_assert_contains "Baseline: stderr asks the user to enter the code" \
+        "$baseline_output" "and enter the code:"
+
+    # The line after the browser prompt is the verification URL.
+    local verification_uri
+    verification_uri=$(echo "$baseline_output" | \
+        sed -n '/To sign in, use a web browser to open the page:/{n;s/^[[:space:]]*//;p;}')
+    sg_assert_not_null "Baseline: verification URL is surfaced" "$verification_uri"
+    sg_assert_contains "Baseline: verification URL is an RSTS URL" \
+        "$verification_uri" "/RSTS/"
+
+    # The line after "and enter the code:" is the user code.
+    local user_code
+    user_code=$(echo "$baseline_output" | \
+        sed -n '/and enter the code:/{n;s/^[[:space:]]*//;p;}')
+    sg_assert_not_null "Baseline: a non-empty user code is surfaced" "$user_code"
+
+    # verification_uri_complete is optional; assert only when surfaced.
+    if echo "$baseline_output" | grep -qi "Or open this URL directly"; then
+        local verification_uri_complete
+        verification_uri_complete=$(echo "$baseline_output" | \
+            sed -n '/Or open this URL directly to skip entering the code:/{n;s/^[[:space:]]*//;p;}')
+        sg_assert_not_null "Baseline: direct verification URL is surfaced when present" \
+            "$verification_uri_complete"
+    else
+        sg_skip "Baseline: direct verification URL" \
+            "appliance did not surface verification_uri_complete"
+    fi
+
+    # ----------------------------------------------------------------------
+    # Test 4: Opt-in true E2E -- scripted no-human approval (LOCAL/no-MFA)
+    # ----------------------------------------------------------------------
+    # Scripted approval via the rSTS LoginController is opt-in and best-effort.
+    # It is limited to the local provider and no-MFA users, and may be skipped
+    # if brittle. Enable it explicitly with SG_DEVICE_CODE_E2E=1.
+    if [ "$SG_DEVICE_CODE_E2E" = "1" ]; then
+        sg_skip "E2E: scripted device-code approval" \
+            "scripted rSTS LoginController approval not yet automated; baseline covers the guaranteed floor"
+    else
+        sg_skip "E2E: scripted device-code approval" \
+            "opt-in only; set SG_DEVICE_CODE_E2E=1 to attempt (LOCAL provider / no-MFA users only)"
+    fi
+}
+
+suite_cleanup()
+{
+    local LoginFile="$HOME/.safeguard_login"
+
+    # Always restore the EXACT original grant-type value captured at setup,
+    # even if the test body failed. Reconnect via PKCE (grant-type-independent)
+    # so this works regardless of the current DeviceCode/ROG state.
+    if [ -n "${SuiteData[OrigGrantTypes]}" ]; then
+        sg_disconnect
+        sg_connect_pkce
+        sg_put_grant_types "${SuiteData[OrigGrantTypes]}" >/dev/null 2>&1 || true
+    fi
+
+    sg_disconnect
+    rm -f "$LoginFile" 2>/dev/null
+}


### PR DESCRIPTION
Adds a device-code login integration test and generalizes the test framework grant-type helpers.

**What''s included**
- `suite-device-code.sh` integration suite (grant-type toggle, disabled-grant error, verification URL received).
- Generalized grant-type helpers in `framework.sh` (beyond Resource Owner), with the prior Resource-Owner helpers retained as wrappers.

**Tests**
- Suite passes; full suite green (12 suites, 287 tests).

Version bumped to 8.3.2 (test-only → micro).