### PR TITLE
Fix curl 8.x version parse dropping --http1.1 on A2A cert auth (#107)

### DIFF
--- a/src/utils/a2a.sh
+++ b/src/utils/a2a.sh
@@ -33,7 +33,16 @@ invoke_a2a_method()
     trap 'rm -f "$CurlErrFile" "$SclientErrFile" "$PassFile" 2>/dev/null' RETURN
 
     if ! $usesclient; then
-        if [ $(curl --version | grep "libcurl" | sed -e 's,curl [0-9]*\.\([0-9]*\).* (.*,\1,') -ge 33 ]; then
+        # Force HTTP/1.1 for client-certificate auth. HTTP/2 forbids the TLS
+        # renegotiation / post-handshake exchange the A2A cert auth relies on, so
+        # letting curl negotiate h2 (via ALPN) breaks cert auth with a 60094.
+        # curl supports --http1.1 since 7.33. Parse major.minor robustly -- the old
+        # single-field parse read the MINOR digit (e.g. "5" from curl 8.5.0) and
+        # wrongly compared it against 33, dropping the flag on curl >= 8.x.
+        _curlver=$(curl --version | sed -n '1s/^curl \([0-9][0-9]*\)\.\([0-9][0-9]*\).*/\1.\2/p')
+        _curlmajor=${_curlver%%.*}
+        _curlminor=${_curlver##*.}
+        if [ "${_curlmajor:-0}" -gt 7 ] || { [ "${_curlmajor:-0}" -eq 7 ] && [ "${_curlminor:-0}" -ge 33 ]; }; then
             http11flag='--http1.1'
         fi
         local bodyargs=()


### PR DESCRIPTION
## Summary

Fixes the curl-version parse in `invoke_a2a_method()` (`src/utils/a2a.sh`) that dropped the `--http1.1` flag on **curl 8.x**, breaking certificate-based A2A retrieval with `60094 Authorization is denied`.

Resolves #107.

## Root cause

The old check parsed a single numeric field from `curl --version` and compared it against `33`. On curl 8.x the captured field is the **minor** digit (e.g. `5` from `curl 8.5.0`), which is `< 33`, so `--http1.1` was silently omitted. curl 8.x then negotiates **HTTP/2** via ALPN, and HTTP/2 forbids the TLS renegotiation / post-handshake client-certificate exchange A2A cert auth depends on (RFC 8740). The request reaches the service without a validated client cert and is denied.

This is more visible on **SPP 9.0 (TLS 1.3)** but the defect is entirely client-side: it bites any modern curl regardless of TLS version.

## Fix

Parse `major.minor` robustly and force `--http1.1` for all curl `>= 7.33` (including 8.x) on the cert-auth path.

## Validation

Reproduced live against SPP 9.0 (TLS 1.3): with the old parse, cert-based A2A retrieval failed `60094` (request went out as HTTP/2); with the fix, curl uses HTTP/1.1 and retrieval succeeds. Verified the parse selects the correct branch for curl `7.33`, `7.68`, and `8.5.0`.

## Scope

Single-file, cert-auth path only. No behavior change for curl `< 7.33` or for the `s_client` fallback path. No server-side change required.